### PR TITLE
FIX - Downloads were not working on iOS platform

### DIFF
--- a/lib/audioplayer/download_class.dart
+++ b/lib/audioplayer/download_class.dart
@@ -9,6 +9,7 @@ import 'package:http/http.dart' as http;
 import 'package:path_provider/path_provider.dart';
 import 'package:pedantic/pedantic.dart';
 import 'package:shared_preferences/shared_preferences.dart';
+import 'player_utils.dart';
 
 class _Download {
   bool isDownloading = false;
@@ -42,8 +43,8 @@ class _Download {
   }
 
   Future<dynamic> _downloadFileWithProgress(AudioFile currentFile) async {
-    var dir = (await getApplicationSupportDirectory()).path;
-    var file = File('$dir/${_mediaItem.id.replaceAll('/', '_')}');
+    var filePath = (await getFilePath(_mediaItem.id));
+    var file = File(filePath);
     if (file.existsSync()) {
       isDownloading = false;
       return null;

--- a/lib/audioplayer/player_utils.dart
+++ b/lib/audioplayer/player_utils.dart
@@ -27,9 +27,8 @@ var bgDownloadListener = ValueNotifier<double>(0);
 int bgTotal = 1, bgReceived = 0;
 
 Future<dynamic> checkFileExists(AudioFile currentFile) async {
-  var dir = (await getApplicationSupportDirectory()).path;
-  var name = currentFile.id;
-  var file = File('$dir/$name');
+  var filePath = (await getFilePath(currentFile.id));
+  var file = File(filePath);
   var exists = await file.exists();
   return exists;
 }
@@ -50,12 +49,16 @@ Future<dynamic> downloadBGMusicFromURL(String id, String name) async {
   return file.path;
 }
 
+Future<String> getFilePath(String mediaItemId) async {
+  var dir = (await getApplicationSupportDirectory()).path;
+  return '$dir/${mediaItemId.replaceAll('/', '_')}.mp3';
+}
+
 Future<dynamic> getDownload(String filename) async {
-  var path = (await getApplicationSupportDirectory()).path;
-  filename = filename.replaceAll(' ', '%20');
-  var file = File('$path/$filename');
+  var path = (await getFilePath(filename));
+  var file = File(path);
   if (await file.exists()) {
-    return file.absolute.path;
+    return file.path;
   } else {
     return null;
   }

--- a/lib/network/sessionoptions/session_options_bloc.dart
+++ b/lib/network/sessionoptions/session_options_bloc.dart
@@ -209,8 +209,8 @@ class SessionOptionsBloc {
 
   Future<dynamic> removeFile(MediaItem currentFile) async {
     removing = true;
-    var dir = (await getApplicationSupportDirectory()).path;
-    var file = File('$dir/${currentFile.id}');
+    var filePath = (await getFilePath(currentFile.id));
+    var file = File(filePath);
 
     if (await file.exists()) {
       await file.delete();


### PR DESCRIPTION
There were two issues mainly:
1. The logic to get path for item was different during downloads and
retrieval
2. The iOS Audio Player requires a file extension to properly play
it. Added mp3 extension while saving the file
3. The toggle for Offline was not deleting the file when selected
No. This was happening due to different file path too