### PR TITLE
FIX the offline button state inconsistency

### DIFF
--- a/lib/network/sessionoptions/session_options_bloc.dart
+++ b/lib/network/sessionoptions/session_options_bloc.dart
@@ -129,6 +129,8 @@ class SessionOptionsBloc {
     // Info is in the form "info": "No voice,00:05:02"
     voiceListController.sink.add(ApiResponse.completed(options.voiceList));
     filterLengthsForVoice();
+
+    await updateCurrentFile();
   }
 
   String _getCoverUrl() => _repo.getImageBaseUrl(_options.cover);

--- a/lib/widgets/sessionoptions/session_options_screen.dart
+++ b/lib/widgets/sessionoptions/session_options_screen.dart
@@ -472,9 +472,6 @@ class _SessionOptionsScreenState extends State<SessionOptionsScreen> {
 
   void onOfflineSelected(int index) {
     _bloc.offlineSelected = index;
-    _bloc.updateCurrentFile();
-
-    _bloc.updateAvailableOfflineIndicatorText();
 
     if (index == 1) {
       // 'YES' selected
@@ -491,6 +488,7 @@ class _SessionOptionsScreenState extends State<SessionOptionsScreen> {
       _bloc.removeFile(_bloc.getMediaItemForSelectedFile()).then((onValue) {
         print('Removed file');
         _bloc.removing = false;
+        _bloc.updateCurrentFile();
         setState(() {});
       }).catchError((onError) {
         print(onError);


### PR DESCRIPTION
1. Check for offline file while opening the session screen so that the
initial state is correct
2. FIX the toggle state when users selected one of Yes/No button

This ensures that the offline toggle is turned On if the download is
already present for this session.