### PR TITLE
chore: fix build on github action

### DIFF
--- a/.github/workflows/flutter.yml
+++ b/.github/workflows/flutter.yml
@@ -33,11 +33,16 @@ jobs:
           max_attempts: 2
           command: flutter pub get
 
+      # This is a quick workaround to make the Github workflow happy.
+      # There should be a better way to handle the keys to improve DX.
+      - name: "Create a dummy auth.dart"
+        run: echo -e "var baseUrl = '';\nvar debugToken = '';\nvar initToken = '';" > ./lib/viewmodel/auth.dart
+
       # - run: flutter pub get
 
       # - run: flutter format --set-exit-if-changed .
 
-      - run: flutter analyze --no-fatal-warnings .
+      - run: flutter analyze --no-fatal-warnings --no-fatal-infos .
 
       - run: flutter test
 

--- a/test/streak_test.dart
+++ b/test/streak_test.dart
@@ -18,8 +18,10 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
 void main() {
-  TestWidgetsFlutterBinding.ensureInitialized();
-  SharedPreferences.setMockInitialValues({});
+
+  setUp(() {
+    SharedPreferences.setMockInitialValues({});
+  });
 
   test('test longerThanOneDayAgo', () {
     var b = longerThanOneDayAgo(DateTime.parse('2020-07-14 11:59:00'),


### PR DESCRIPTION
## Description
- I was first time trying to build and run tests but `flutter test` failed for `streak_test`. Running individual tests in IDE works though. I found that the mocked SharedPreferences was not reset on each test so they don't start in a clean state. Moving the mocked initialization in `setUp` function to re-initialize them before each test fixed the issue. Also, `streak_test` are unit tests, we shouldn't need `TestWidgetsFlutterBinding.ensureInitialized();`

- The github actions were not able to run successfully on the recent commits because:
  - The project doesn't compile without `auth.dart`. I fixed that by adding a step to create a dummy `auth.dart` with empty tokens.
  - `flutter analyze` treated info issues as fatal (exit code = 1). I fixed that by using `--no-fatal-infos` flag

## How I tested this change
The changes do not affect the user-facing application. They are merely for developers. I tested the GH actions in my fork https://github.com/qtdzz/medito-app/actions/runs/804788269