### PR TITLE
test: add some more unit tests for home bloc

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,7 +59,7 @@ ios/*
 **/ios/Flutter/App.framework
 **/ios/Flutter/Flutter.framework
 **/ios/Flutter/Generated.xcconfig
-ios/Flutter/flutter_export_environment.sh
+**/ios/Flutter/flutter_export_environment.sh
 **/ios/Flutter/app.flx
 **/ios/Flutter/app.zip
 **/ios/Flutter/flutter_assets/

--- a/lib/network/api_response.dart
+++ b/lib/network/api_response.dart
@@ -13,7 +13,9 @@ Affero GNU General Public License for more details.
 You should have received a copy of the Affero GNU General Public License
 along with Medito App. If not, see <https://www.gnu.org/licenses/>.*/
 
-class ApiResponse<T> {
+import 'package:equatable/equatable.dart';
+
+class ApiResponse<T> extends Equatable {
   Status status;
   T body;
   String message;
@@ -30,6 +32,9 @@ class ApiResponse<T> {
   String toString() {
     return 'Status : $status \n Message : $message \n Data : $body';
   }
+
+  @override
+  List<Object> get props => [status, body, message];
 }
 
 enum Status { LOADING, COMPLETED, ERROR }

--- a/lib/network/home/home_bloc.dart
+++ b/lib/network/home/home_bloc.dart
@@ -19,16 +19,16 @@ import 'package:Medito/network/api_response.dart';
 import 'package:Medito/network/home/home_repo.dart';
 import 'package:Medito/network/home/menu_response.dart';
 import 'package:Medito/utils/utils.dart';
+import 'package:connectivity/connectivity.dart';
+import 'package:flutter/foundation.dart';
 
 class HomeBloc {
-  HomeRepo _repo;
+  final HomeRepo _repo;
   StreamController<ApiResponse<MenuResponse>> menuList;
   StreamController<bool> connectionStreamController;
   StreamController<String> titleText;
 
-  HomeBloc() {
-    _repo = HomeRepo();
-
+  HomeBloc({@required HomeRepo repo}) : _repo = repo {
     menuList = StreamController.broadcast()..sink.add(ApiResponse.loading());
     titleText = StreamController.broadcast();
     connectionStreamController = StreamController.broadcast();
@@ -57,5 +57,11 @@ class HomeBloc {
     } else {
       return 'Good evening';
     }
+  }
+
+  void dispose() {
+    menuList?.close();
+    connectionStreamController?.close();
+    titleText?.close();
   }
 }

--- a/lib/network/home/menu_response.dart
+++ b/lib/network/home/menu_response.dart
@@ -1,15 +1,19 @@
-class MenuResponse {
-  List<MenuData> data;
+import 'package:equatable/equatable.dart';
+
+class MenuResponse extends Equatable {
+  final List<MenuData> data;
 
   MenuResponse({this.data});
 
-  MenuResponse.fromJson(Map<String, dynamic> json) {
+  factory MenuResponse.fromJson(Map<String, dynamic> json) {
     if (json['data'] != null) {
-      data = <MenuData>[];
+      var _data = <MenuData>[];
       json['data'].forEach((v) {
-        data.add(MenuData.fromJson(v));
+        _data.add(MenuData.fromJson(v));
       });
+      return MenuResponse(data: _data);
     }
+    return MenuResponse(data: []);
   }
 
   Map<String, dynamic> toJson() {
@@ -19,19 +23,23 @@ class MenuResponse {
     }
     return data;
   }
+
+  @override
+  List<Object> get props => [data];
 }
 
-class MenuData {
-  String itemLabel;
-  String itemType;
-  String itemPath;
+class MenuData extends Equatable {
+  final String itemLabel;
+  final String itemType;
+  final String itemPath;
 
-  MenuData({itemLabel, itemType, itemPath});
+  MenuData({this.itemLabel, this.itemType, this.itemPath});
 
-  MenuData.fromJson(Map<String, dynamic> json) {
-    itemLabel = json['item_label'];
-    itemType = json['item_type'];
-    itemPath = json['item_path'];
+  factory MenuData.fromJson(Map<String, dynamic> json) {
+    var _itemLabel = json['item_label'];
+    var _itemType = json['item_type'];
+    var _itemPath = json['item_path'];
+    return MenuData(itemLabel: _itemLabel, itemType: _itemType, itemPath: _itemPath);
   }
 
   Map<String, dynamic> toJson() {
@@ -41,4 +49,7 @@ class MenuData {
     data['item_path'] = itemPath;
     return data;
   }
+
+  @override
+  List<Object> get props => [itemLabel, itemType, itemPath];
 }

--- a/lib/widgets/btm_nav/home_widget.dart
+++ b/lib/widgets/btm_nav/home_widget.dart
@@ -17,6 +17,7 @@ import 'dart:async';
 
 import 'package:Medito/network/api_response.dart';
 import 'package:Medito/network/home/home_bloc.dart';
+import 'package:Medito/network/home/home_repo.dart';
 import 'package:Medito/network/home/menu_response.dart';
 import 'package:Medito/tracking/tracking.dart';
 import 'package:Medito/network/user/user_utils.dart';
@@ -41,7 +42,7 @@ class HomeWidget extends StatefulWidget {
 }
 
 class _HomeWidgetState extends State<HomeWidget> {
-  final _bloc = HomeBloc();
+  final _bloc = HomeBloc(repo: HomeRepo());
 
   final GlobalKey<AnnouncementBannerState> _announceKey = GlobalKey();
 
@@ -233,6 +234,7 @@ class _HomeWidgetState extends State<HomeWidget> {
   void dispose() {
     super.dispose();
     subscription.cancel();
+    _bloc.dispose();
   }
 
   void _observeNetwork() {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -41,10 +41,12 @@ dependencies:
   connectivity: ^3.0.3
   device_info: ^2.0.0
   dart_ipify: ^1.0.2
+  equatable: ^2.0.0
 
 dev_dependencies:
   flutter_test:
     sdk: flutter
+  mocktail: ^0.1.2
 
 
 # For information on the generic Dart part of this file, see the

--- a/test/home_test.dart
+++ b/test/home_test.dart
@@ -1,9 +1,23 @@
+import 'package:Medito/network/api_response.dart';
 import 'package:Medito/network/home/home_bloc.dart';
+import 'package:Medito/network/home/home_repo.dart';
+import 'package:Medito/network/home/menu_response.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+
+class MockHomeRepo extends Mock implements HomeRepo {}
 
 void main() {
+  HomeRepo _mockHomeRepo;
+  HomeBloc _bloc;
+
+  setUp(() {
+    _mockHomeRepo = MockHomeRepo();
+    _bloc = HomeBloc(repo: _mockHomeRepo);
+  });
+
   test('test greeting text', () async {
-    var bloc = HomeBloc();
+    var bloc = HomeBloc(repo: _mockHomeRepo);
     var now = DateTime(2021, 3, 1, 12, 30);
     var b = await bloc.getTitleText(now);
     expect(b, 'Good afternoon');
@@ -21,4 +35,43 @@ void main() {
     b = await bloc.getTitleText(now);
     expect(b, 'Good evening');
   });
+
+  test('menuList should broadcast ApiResponse data when repo responses data',
+      () async {
+    var expectedMenuResponse = _createMockMenuResponse();
+    when(() => _mockHomeRepo.fetchMenu(false))
+        .thenAnswer((realInvocation) async => expectedMenuResponse);
+    var bloc = HomeBloc(repo: _mockHomeRepo);
+    var firstResponse = bloc.menuList.stream.first;
+
+    await bloc.fetchMenu();
+    expect(await firstResponse, ApiResponse.completed(expectedMenuResponse));
+  });
+
+  test('menuList should broadcast ApiResponse error when repo throws',
+      () async {
+    when(() => _mockHomeRepo.fetchMenu(false)).thenThrow(Error());
+    var firstResponse = _bloc.menuList.stream.first;
+
+    await _bloc.fetchMenu();
+    var apiResponse = (await firstResponse);
+    expect(apiResponse.status, Status.ERROR);
+    expect(apiResponse.body, null);
+  });
+
+  tearDown(() {
+    _bloc?.dispose();
+  });
+}
+
+MenuResponse _createMockMenuResponse() {
+  var item = {
+    'item_label': 'mock_item_label',
+    'item_type': 'mock_item_type',
+    'item_path': 'mock_item_path'
+  };
+  var mockData = {
+    'data': [item]
+  };
+  return MenuResponse.fromJson(mockData);
 }


### PR DESCRIPTION
## Description
- Add some small tests for home_bloc
- Add [`equatable`](https://pub.dev/packages/equatable) package (MIT license): this library allows comparing the  equality of the object without writing a lot of boilerplate code such as overriding `==` operator and `hashCode` method. I use this for compare the results in unit tests.
- Add [`mocktail`](https://pub.dev/packages/mocktail) package (MIT license): this library allows mocking objects in a very simple way (you can check the documentation in their package). I need this to mock external dependencies for the testing target. I think it's useful for testing in general. (I tried `mockito` as the flutter documentation but it requires some code generation which is not neat IMHO. So I prefer to use `mocktail` to avoid the code generation... )
- Inject the `HomeRepo` into `HomeBloc` instead of hard-cording in the constructor. This way will help us easily test the `HomeBloc` without caring too much about `HomeRepo`. We can simply mock the HomeRepo and manipulate its data in the way we want.

## Note 
- I noticed that the code base has the coupling issue between layers (Repo-Bloc-Widget) in most of the place. I can start decoupling them one by one when writing tests but it would be nice if we are conscious about this in the future implementation. Please let me know what you think...

## Test
- I manually tested the app. It works :)
 