### PR TITLE
fix: fix sticky stats position on cold start

### DIFF
--- a/lib/widgets/home/courses_row_widget.dart
+++ b/lib/widgets/home/courses_row_widget.dart
@@ -23,14 +23,13 @@ class CoursesRowWidgetState extends State<CoursesRowWidget> {
 
   @override
   Widget build(BuildContext context) {
-    return Column(
-      crossAxisAlignment: CrossAxisAlignment.start,
-      children: [
-        Padding(
-          padding: const EdgeInsets.only(top: 32.0, left: 16, bottom: 8.0),
-          child: Text('Courses', style: Theme.of(context).textTheme.headline3),
-        ),
-        StreamBuilder<ApiResponse<CoursesResponse>>(
+    return Column(crossAxisAlignment: CrossAxisAlignment.start, children: [
+      Padding(
+        padding: const EdgeInsets.only(top: 32.0, left: 16, bottom: 8.0),
+        child: Text('Courses', style: Theme.of(context).textTheme.headline3),
+      ),
+      SizeChangedLayoutNotifier(
+        child: StreamBuilder<ApiResponse<CoursesResponse>>(
             stream: _bloc.coursesList.stream,
             initialData: ApiResponse.loading(),
             builder: (context, snapshot) {
@@ -48,8 +47,8 @@ class CoursesRowWidgetState extends State<CoursesRowWidget> {
               }
               return Container();
             }),
-      ],
-    );
+      ),
+    ]);
   }
 
   Widget _horizontalCoursesRow(

--- a/lib/widgets/home/daily_message_widget.dart
+++ b/lib/widgets/home/daily_message_widget.dart
@@ -22,33 +22,37 @@ class DailyMessageWidgetState extends State<DailyMessageWidget> {
 
   @override
   Widget build(BuildContext context) {
-    return StreamBuilder<ApiResponse<DailyMessageResponse>>(
-        stream: _bloc.coursesList.stream,
-        builder: (context, snapshot) {
-          var widget;
+    return SizeChangedLayoutNotifier(
+      child: StreamBuilder<ApiResponse<DailyMessageResponse>>(
+          stream: _bloc.coursesList.stream,
+          builder: (context, snapshot) {
+            var widget;
 
-          if (!snapshot.hasData || snapshot.data == null || snapshot.data.body.body.isEmptyOrNull()) {
-            return Container();
-          }
+            if (!snapshot.hasData ||
+                snapshot.data == null ||
+                snapshot.data.body.body.isEmptyOrNull()) {
+              return Container();
+            }
 
-          switch (snapshot.data.status) {
-            case Status.LOADING:
-              widget = const CircularProgressIndicator();
-              break;
-            case Status.COMPLETED:
-              widget = _getMessageWidget(snapshot, context);
-              break;
-            case Status.ERROR:
-              widget = Container();
-              break;
-          }
+            switch (snapshot.data.status) {
+              case Status.LOADING:
+                widget = const CircularProgressIndicator();
+                break;
+              case Status.COMPLETED:
+                widget = _getMessageWidget(snapshot, context);
+                break;
+              case Status.ERROR:
+                widget = Container();
+                break;
+            }
 
-          return Padding(
-            padding: const EdgeInsets.only(
-                left: 16.0, right: 16.0, bottom: 32.0, top: 32.0),
-            child: widget,
-          );
-        });
+            return Padding(
+              padding: const EdgeInsets.only(
+                  left: 16.0, right: 16.0, bottom: 32.0, top: 32.0),
+              child: widget,
+            );
+          }),
+    );
   }
 
   Widget _getMessageWidget(
@@ -74,8 +78,6 @@ class DailyMessageWidgetState extends State<DailyMessageWidget> {
       ),
     );
   }
-
-
 
   void _launchUrl(String text, String href, String title) {
     launchUrl(href);

--- a/lib/widgets/home/small_shortcuts_row_widget.dart
+++ b/lib/widgets/home/small_shortcuts_row_widget.dart
@@ -31,40 +31,42 @@ class SmallShortcutsRowWidgetState extends State<SmallShortcutsRowWidget> {
 
   @override
   Widget build(BuildContext context) {
-    return StreamBuilder<ApiResponse<ShortcutsResponse>>(
-        stream: _bloc.shortcutList.stream,
-        initialData: ApiResponse.loading(),
-        builder: (context, snapshot) {
-          switch (snapshot.data.status) {
-            case Status.LOADING:
-              return _getLoadingWidget();
-              break;
-            case Status.COMPLETED:
-              return GridView.count(
-                crossAxisCount: 2,
-                padding:
-                    const EdgeInsets.only(left: 12.0, right: 12.0, top: 8.0),
-                scrollDirection: Axis.vertical,
-                childAspectRatio: 2.6,
-                physics: NeverScrollableScrollPhysics(),
-                shrinkWrap: true,
-                children:
-                    List.generate(snapshot.data.body?.data?.length ?? 0, (index) {
-                  return Card(
-                    clipBehavior: Clip.antiAlias,
-                    color: MeditoColors.deepNight,
-                    child: SmallShortcutWidget(
-                        snapshot.data.body.data[index], widget.onTap),
-                  );
-                }),
-              );
-              break;
-            case Status.ERROR:
-              return Icon(Icons.error);
-              break;
-          }
-          return Container();
-        });
+    return SizeChangedLayoutNotifier(
+      child: StreamBuilder<ApiResponse<ShortcutsResponse>>(
+          stream: _bloc.shortcutList.stream,
+          initialData: ApiResponse.loading(),
+          builder: (context, snapshot) {
+            switch (snapshot.data.status) {
+              case Status.LOADING:
+                return _getLoadingWidget();
+                break;
+              case Status.COMPLETED:
+                return GridView.count(
+                  crossAxisCount: 2,
+                  padding:
+                      const EdgeInsets.only(left: 12.0, right: 12.0, top: 8.0),
+                  scrollDirection: Axis.vertical,
+                  childAspectRatio: 2.6,
+                  physics: NeverScrollableScrollPhysics(),
+                  shrinkWrap: true,
+                  children: List.generate(snapshot.data.body?.data?.length ?? 0,
+                      (index) {
+                    return Card(
+                      clipBehavior: Clip.antiAlias,
+                      color: MeditoColors.deepNight,
+                      child: SmallShortcutWidget(
+                          snapshot.data.body.data[index], widget.onTap),
+                    );
+                  }),
+                );
+                break;
+              case Status.ERROR:
+                return Icon(Icons.error);
+                break;
+            }
+            return Container();
+          }),
+    );
   }
 
   Widget _getLoadingWidget() => GridView.count(

--- a/lib/widgets/home/stats_widget.dart
+++ b/lib/widgets/home/stats_widget.dart
@@ -18,15 +18,14 @@ class _StatsWidgetState extends State<StatsWidget> {
       children: [
         Padding(
           padding: const EdgeInsets.only(left: 16.0, bottom: 8.0),
-          child: Text('Stats',
-              style: Theme.of(context).textTheme.headline3),
+          child: Text('Stats', style: Theme.of(context).textTheme.headline3),
         ),
         SizedBox(
           height: 73,
           child: ListView.builder(
             padding: const EdgeInsets.only(left: 8.0, right: 8.0),
             itemBuilder: (context, i) => statsItem(context, i),
-            itemCount: 5,
+            itemCount: 4,
             scrollDirection: Axis.horizontal,
             shrinkWrap: true,
           ),

--- a/lib/widgets/packs/expand_animate_widget.dart
+++ b/lib/widgets/packs/expand_animate_widget.dart
@@ -71,10 +71,9 @@ class _ExpandedSectionState extends State<ExpandedSection> with SingleTickerProv
 
   @override
   Widget build(BuildContext context) {
-    return SizeTransition(
-      axisAlignment: 1.0,
-      sizeFactor: animation,
-      child: widget.child
+    return SizeChangedLayoutNotifier(
+      child: SizeTransition(
+          axisAlignment: 1.0, sizeFactor: animation, child: widget.child),
     );
   }
 }


### PR DESCRIPTION
## Description
- Fix https://github.com/meditohq/medito-app/issues/127.
- The problem is from the `Ink` widgets which are used to build the `stats_widget` . From their documentation:
```
/// This widget is subject to the same limitations as other ink effects, as
/// described in the documentation for [Material]. Most notably, the position of
/// an [Ink] widget must not change during the lifetime of the [Material] object
/// unless a [LayoutChangedNotification] is dispatched each frame that the
/// position changes. This is done automatically for [ListView] and other
/// scrolling widgets, but is not done for animated transitions such as
/// [SlideTransition].
```
- On the home page, Medito has 3 parts moving at the beginning (which I think we should fix to create better first impression): the announcement animation, shortcuts switching from waiting boxes to the real shortcuts, and courses switching from waiting boxes to the real content. None of these layout changes are notified to the parent widget. Daily messages popping up is also changing the layout but it is a part of ListView, so the `Ink` components response correctly. That's why sometime we see it stuck in different positions. The order of the moving parts affect the stucking position.
- I fixed it by simply wrapping these moving components in a `SizeChangedLayoutNotifier`.  

## Test
- Unfortunately, I can't create any test for this but only manually testing them:

Before: 

https://user-images.githubusercontent.com/11023947/118295643-6548b280-b4dc-11eb-85e4-803b0e506eca.mp4

After:

https://user-images.githubusercontent.com/11023947/118295625-6083fe80-b4dc-11eb-86d0-7c87caccafe5.mp4
