### PR TITLE
chore: improve animation on homescreen

### DIFF
--- a/lib/widgets/home/courses_row_item_widget.dart
+++ b/lib/widgets/home/courses_row_item_widget.dart
@@ -1,0 +1,111 @@
+import 'package:Medito/network/home/courses_response.dart';
+import 'package:Medito/utils/colors.dart';
+import 'package:Medito/utils/utils.dart';
+import 'package:Medito/widgets/home/loading_text_box_widget.dart';
+import 'package:flutter/material.dart';
+
+class CoursesRowItemWidget extends StatelessWidget {
+  const CoursesRowItemWidget({@required this.data, Key key, this.onTap})
+      : super(key: key);
+
+  final void Function(dynamic, dynamic) onTap;
+
+  final Data data;
+
+  factory CoursesRowItemWidget.waiting({Key key}) {
+    return CoursesRowItemWidget(
+      data: null,
+      key: key,
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return GestureDetector(
+      onTap: _createOnTap(),
+      child: Container(
+        width: 148,
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            _imageStack(),
+            Container(height: 8),
+            Padding(
+              padding: const EdgeInsets.only(right: 16.0),
+              child: _createTitle(context),
+            ),
+            Container(height: 2),
+            Padding(
+              padding: const EdgeInsets.only(right: 16.0),
+              child: _createSubtitle(context),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _createSubtitle(BuildContext context) {
+    if (data != null) {
+      return Text(data.subtitle, style: Theme.of(context).textTheme.subtitle1);
+    } else {
+      return LoadingTextBoxWidget(height: 21);
+    }
+  }
+
+  Widget _createTitle(BuildContext context) {
+    if (data != null) {
+      return Text(data.title, style: Theme.of(context).textTheme.headline4);
+    } else {
+      return LoadingTextBoxWidget(height: 42);
+    }
+  }
+
+  void Function() _createOnTap() {
+    if (data != null && onTap != null) {
+      return () => onTap(data.type, data.id);
+    } else {
+      return () {};
+    }
+  }
+
+  Stack _imageStack() {
+    return Stack(
+      children: [
+        SizedBox(width: 132, height: 132, child: _buildCardBackground()),
+        Positioned.fill(
+          child: Center(
+            child: SizedBox(
+                width: 92, height: 92, child: _getNetworkImageWidget()),
+          ),
+        ),
+      ],
+    );
+  }
+
+  Widget _getNetworkImageWidget() {
+    if (data != null) {
+      return getNetworkImageWidget(data.coverUrl);
+    } else {
+      return Container(
+        color: MeditoColors.moonlight,
+      );
+    }
+  }
+
+  Widget _buildCardBackground() {
+    if (data != null) {
+      return data.backgroundImage.isEmptyOrNull()
+          ? Container(
+              color: data.colorPrimary.isEmptyOrNull()
+                  ? MeditoColors.moonlight
+                  : parseColor(data.colorPrimary))
+          : getNetworkImageWidget(data.backgroundImageUrl);
+    } else {
+      return Container(
+        color: MeditoColors.moonlight,
+      );
+    }
+  }
+}

--- a/lib/widgets/home/courses_row_widget.dart
+++ b/lib/widgets/home/courses_row_widget.dart
@@ -1,8 +1,7 @@
 import 'package:Medito/network/api_response.dart';
 import 'package:Medito/network/home/courses_bloc.dart';
 import 'package:Medito/network/home/courses_response.dart';
-import 'package:Medito/utils/colors.dart';
-import 'package:Medito/utils/utils.dart';
+import 'package:Medito/widgets/home/courses_row_item_widget.dart';
 import 'package:flutter/material.dart';
 
 class CoursesRowWidget extends StatefulWidget {
@@ -22,6 +21,12 @@ class CoursesRowWidgetState extends State<CoursesRowWidget> {
   }
 
   @override
+  void initState() {
+    super.initState();
+    _bloc.fetchCourses();
+  }
+
+  @override
   Widget build(BuildContext context) {
     return Column(crossAxisAlignment: CrossAxisAlignment.start, children: [
       Padding(
@@ -33,35 +38,47 @@ class CoursesRowWidgetState extends State<CoursesRowWidget> {
             stream: _bloc.coursesList.stream,
             initialData: ApiResponse.loading(),
             builder: (context, snapshot) {
-              switch (snapshot.data.status) {
-                case Status.LOADING:
-                  return _getLoadingWidget();
-                  break;
-                case Status.COMPLETED:
-                  return _horizontalCoursesRow(snapshot);
-
-                  break;
-                case Status.ERROR:
-                  return Icon(Icons.error);
-                  break;
-              }
-              return Container();
+              return AnimatedSwitcher(
+                duration: Duration(milliseconds: 100),
+                child: _buildCoursesRowWidget(snapshot),
+              );
             }),
       ),
     ]);
   }
 
-  Widget _horizontalCoursesRow(
+  Widget _buildCoursesRowWidget(
       AsyncSnapshot<ApiResponse<CoursesResponse>> snapshot) {
+    switch (snapshot.data.status) {
+      case Status.LOADING:
+        return _horizontalCoursesRow(null, ValueKey('CoursesRowLoading'));
+      case Status.COMPLETED:
+        return _horizontalCoursesRow(snapshot, ValueKey('CoursesRowCompleted'));
+      case Status.ERROR:
+        return Icon(Icons.error);
+      default:
+        return Container();
+    }
+  }
+
+  Widget _horizontalCoursesRow(
+      AsyncSnapshot<ApiResponse<CoursesResponse>> snapshot, Key key) {
     var list = <Widget>[Container(width: 16)];
-    snapshot.data?.body?.data?.forEach((element) {
-      list.add(CoursesRowItemWidget(
-        element,
-        onTap: widget.onTap,
-      ));
-    });
+    if (snapshot != null) {
+      snapshot.data?.body?.data?.forEach((element) {
+        list.add(CoursesRowItemWidget(
+          data: element,
+          onTap: widget.onTap,
+        ));
+      });
+    } else {
+      list.addAll(List.generate(4, (index) {
+        return CoursesRowItemWidget.waiting();
+      }));
+    }
 
     return SingleChildScrollView(
+      key: key,
       scrollDirection: Axis.horizontal,
       child: Row(
         mainAxisAlignment: MainAxisAlignment.start,
@@ -70,76 +87,4 @@ class CoursesRowWidgetState extends State<CoursesRowWidget> {
       ),
     );
   }
-
-  Widget _getLoadingWidget() => Row(
-        children: [
-          Container(width: 16),
-          Container(color: MeditoColors.moonlight, height: 132, width: 132),
-          Container(width: 16),
-          Container(color: MeditoColors.moonlight, height: 132, width: 132),
-        ],
-      );
-}
-
-class CoursesRowItemWidget extends StatelessWidget {
-  const CoursesRowItemWidget(this.data, {Key key, this.onTap})
-      : super(key: key);
-
-  final void Function(dynamic, dynamic) onTap;
-
-  final Data data;
-
-  @override
-  Widget build(BuildContext context) {
-    return GestureDetector(
-      onTap: () => onTap(data.type, data.id),
-      child: Container(
-        width: 148,
-        child: Column(
-          mainAxisSize: MainAxisSize.min,
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            _imageStack(),
-            Container(height: 8),
-            Padding(
-              padding: const EdgeInsets.only(right: 16.0),
-              child: Text(
-                data.title,
-                style: Theme.of(context).textTheme.headline4,
-              ),
-            ),
-            Container(height: 2),
-            Padding(
-              padding: const EdgeInsets.only(right: 16.0),
-              child: Text(data.subtitle,
-                  style: Theme.of(context).textTheme.subtitle1),
-            ),
-          ],
-        ),
-      ),
-    );
-  }
-
-  Stack _imageStack() {
-    return Stack(
-      children: [
-        SizedBox(width: 132, height: 132, child: _buildCardBackground()),
-        Positioned.fill(
-          child: Center(
-            child: SizedBox(
-                width: 92,
-                height: 92,
-                child: getNetworkImageWidget(data.coverUrl)),
-          ),
-        ),
-      ],
-    );
-  }
-
-  Widget _buildCardBackground() => data.backgroundImage.isEmptyOrNull()
-      ? Container(
-          color: data.colorPrimary.isEmptyOrNull()
-              ? MeditoColors.moonlight
-              : parseColor(data.colorPrimary))
-      : getNetworkImageWidget(data.backgroundImageUrl);
 }

--- a/lib/widgets/home/daily_message_item_widget.dart
+++ b/lib/widgets/home/daily_message_item_widget.dart
@@ -1,0 +1,74 @@
+import 'package:Medito/network/home/daily_message_response.dart';
+import 'package:Medito/utils/utils.dart';
+import 'package:Medito/widgets/home/loading_text_box_widget.dart';
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_markdown/flutter_markdown.dart';
+import 'package:share/share.dart';
+
+class DailyMessageItemWidget extends StatelessWidget {
+  final DailyMessageResponse data;
+
+  DailyMessageItemWidget({Key key, @required this.data}) : super(key: key);
+
+  factory DailyMessageItemWidget.loading({Key key}) {
+    return DailyMessageItemWidget(
+      data: null,
+      key: key,
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.only(
+          left: 16.0, right: 16.0, bottom: 32.0, top: 32.0),
+      child: GestureDetector(
+        onTap: _createShareAction(data),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            _buildTitle(context),
+            Padding(
+              padding: const EdgeInsets.only(top: 8),
+              child: _buildMarkdownBody(context),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildMarkdownBody(BuildContext context) {
+    if (data != null) {
+      return MarkdownBody(
+        data: data.body,
+        onTapLink: _launchUrl,
+        styleSheet: MarkdownStyleSheet.fromTheme(Theme.of(context))
+            .copyWith(p: Theme.of(context).textTheme.bodyText1),
+      );
+    } else {
+      return LoadingTextBoxWidget(height: 60);
+    }
+  }
+
+  Widget _buildTitle(BuildContext context) {
+    if (data != null) {
+      return Text(data.title, style: Theme.of(context).textTheme.headline3);
+    } else {
+      return LoadingTextBoxWidget(height: 23);
+    }
+  }
+
+  Future<void> Function() _createShareAction(DailyMessageResponse data) {
+    if (data != null) {
+      return () => Share.share('${data.body} https://medito.app');
+    } else {
+      return () async {};
+    }
+  }
+
+  void _launchUrl(String text, String href, String title) {
+    launchUrl(href);
+  }
+}

--- a/lib/widgets/home/daily_message_widget.dart
+++ b/lib/widgets/home/daily_message_widget.dart
@@ -2,11 +2,11 @@ import 'package:Medito/network/api_response.dart';
 import 'package:Medito/network/home/daily_message_bloc.dart';
 import 'package:Medito/network/home/daily_message_response.dart';
 import 'package:Medito/utils/utils.dart';
+import 'package:Medito/widgets/home/daily_message_item_widget.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter_markdown/flutter_markdown.dart';
-import 'package:share/share.dart';
 
 class DailyMessageWidget extends StatefulWidget {
+
   @override
   DailyMessageWidgetState createState() => DailyMessageWidgetState();
 
@@ -27,54 +27,37 @@ class DailyMessageWidgetState extends State<DailyMessageWidget> {
           stream: _bloc.coursesList.stream,
           initialData: ApiResponse.loading(),
           builder: (context, snapshot) {
-            var widget;
-
-            switch (snapshot.data.status) {
-              case Status.LOADING:
-                widget = const CircularProgressIndicator();
-                break;
-              case Status.COMPLETED:
-                widget = _getMessageWidget(snapshot, context);
-                break;
-              case Status.ERROR:
-                widget = Container();
-                break;
-            }
-
-            return Padding(
-              padding: const EdgeInsets.only(
-                  left: 16.0, right: 16.0, bottom: 32.0, top: 32.0),
-              child: widget,
+            return AnimatedSwitcher(
+              duration: Duration(milliseconds: 100),
+              child: _buildDailyMessageItemWidget(snapshot),
             );
           }),
     );
   }
 
-  Widget _getMessageWidget(
-      AsyncSnapshot<ApiResponse<DailyMessageResponse>> snapshot,
-      BuildContext context) {
-    return GestureDetector(
-      onTap: () => Share.share('${snapshot.data.body?.body} https://medito.app'),
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          Text(snapshot.data.body?.title,
-              style: Theme.of(context).textTheme.headline3),
-          Padding(
-            padding: const EdgeInsets.only(top: 8),
-            child: MarkdownBody(
-              data: snapshot.data.body?.body,
-              onTapLink: _launchUrl,
-              styleSheet: MarkdownStyleSheet.fromTheme(Theme.of(context))
-                  .copyWith(p: Theme.of(context).textTheme.bodyText1),
-            ),
-          ),
-        ],
-      ),
-    );
-  }
-
-  void _launchUrl(String text, String href, String title) {
-    launchUrl(href);
+  Widget _buildDailyMessageItemWidget(
+      AsyncSnapshot<ApiResponse<DailyMessageResponse>> snapshot) {
+    if (!snapshot.hasData ||
+        snapshot.data == null ||
+        snapshot.data.body == null ||
+        snapshot.data.body.body.isEmptyOrNull()) {
+      return DailyMessageItemWidget.loading(
+          key: ValueKey('DailyMessageLoading'));
+    } else {
+      switch (snapshot.data.status) {
+        case Status.LOADING:
+          return DailyMessageItemWidget.loading(
+            key: ValueKey('DailyMessageLoading'),
+          );
+        case Status.COMPLETED:
+          return DailyMessageItemWidget(
+            data: snapshot.data.body,
+            key: ValueKey('DailyMessageCompleted'),
+          );
+        case Status.ERROR:
+        default:
+          return Container();
+      }
+    }
   }
 }

--- a/lib/widgets/home/loading_text_box_widget.dart
+++ b/lib/widgets/home/loading_text_box_widget.dart
@@ -1,0 +1,19 @@
+import 'package:Medito/utils/colors.dart';
+import 'package:flutter/cupertino.dart';
+
+class LoadingTextBoxWidget extends StatelessWidget {
+  final double height;
+
+  LoadingTextBoxWidget({this.height});
+
+  @override
+  Widget build(BuildContext context) {
+    return ClipRRect(
+        borderRadius: BorderRadius.circular(10.0),
+        child: Container(
+            child: Container(
+          color: MeditoColors.moonlight,
+          height: height,
+        )));
+  }
+}

--- a/lib/widgets/packs/expand_animate_widget.dart
+++ b/lib/widgets/packs/expand_animate_widget.dart
@@ -27,7 +27,7 @@ class ExpandedSection extends StatefulWidget {
 
 class _ExpandedSectionState extends State<ExpandedSection> with SingleTickerProviderStateMixin {
   AnimationController expandController;
-  Animation<double> animation; 
+  Animation<double> animation;
 
   @override
   void initState() {

--- a/test/widgets/WidgetTestUtil.dart
+++ b/test/widgets/WidgetTestUtil.dart
@@ -1,0 +1,19 @@
+import 'package:flutter/material.dart';
+
+class WidgetTestUtil {
+  // Wrapping the widget with MaterialApp because it needs to know the text direction (LTR or RTL)
+  // and ScaffoldMessenger for showing the snackbar.
+  // This is only needed when testing individual widget.
+  // The app works without it because it is wrapped with MaterialApp at the top level.
+  static Widget wrapWidgetForTesting({@required Widget child}) {
+    return MaterialApp(
+      title: 'TestAppWrapper',
+      home: Scaffold(
+        appBar: AppBar(
+          title: Text('TestAppBar'),
+        ),
+        body: child,
+      ),
+    );
+  }
+}

--- a/test/widgets/home/courses_row_item_widget_test.dart
+++ b/test/widgets/home/courses_row_item_widget_test.dart
@@ -1,0 +1,95 @@
+import 'package:Medito/network/home/courses_response.dart';
+import 'package:Medito/widgets/home/courses_row_item_widget.dart';
+import 'package:Medito/widgets/home/daily_message_item_widget.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import '../WidgetTestUtil.dart';
+
+void main() {
+  var testData;
+
+  setUp(() {
+    testData = Data(
+      title: 'test_title',
+      subtitle: 'test_subtitle',
+      backgroundImage: 'test_backgroundImage',
+      type: 'test_type',
+      id: 'test_id',
+      cover: 'test_cover',
+      colorPrimary: Colors.black.toString(),
+    );
+  });
+
+  testWidgets('coursesRowItemWidget should have title and subtitle',
+          (WidgetTester tester) async {
+        var testingWidget = WidgetTestUtil.wrapWidgetForTesting(
+            child: CoursesRowItemWidget(data: testData));
+
+        await tester.pumpWidget(testingWidget);
+
+        var title = find.text('test_title');
+        expect(title, findsOneWidget);
+
+        var subtitle = find.text('test_subtitle');
+        expect(subtitle, findsOneWidget);
+      });
+
+  testWidgets(
+      'coursesRowItemWidget should execute onTap action on selected item',
+          (WidgetTester tester) async {
+        var onTapData = {};
+        var testingWidget = WidgetTestUtil.wrapWidgetForTesting(
+            child: CoursesRowItemWidget(
+              data: testData,
+              onTap: (type, id) {
+                onTapData['type'] = type;
+                onTapData['id'] = id;
+              },
+            ));
+        await tester.pumpWidget(testingWidget);
+        await tester.tap(find.byType(CoursesRowItemWidget));
+        await tester.pumpAndSettle();
+        expect(onTapData['type'], 'test_type');
+        expect(onTapData['id'], 'test_id');
+      });
+
+  testWidgets(
+      'coursesRowItemWidget should execute onTap action on selected waiting item',
+          (WidgetTester tester) async {
+        var testingWidget = WidgetTestUtil.wrapWidgetForTesting(
+            child: CoursesRowItemWidget.waiting());
+        await tester.pumpWidget(testingWidget);
+        await tester.tap(find.byType(CoursesRowItemWidget));
+        await tester.pumpAndSettle();
+      });
+
+  testWidgets('coursesRowItemWidget should not throw when onTap is null',
+          (WidgetTester tester) async {
+        var testingWidget = WidgetTestUtil.wrapWidgetForTesting(
+            child: CoursesRowItemWidget(data: testData, onTap: null));
+        await tester.pumpWidget(testingWidget);
+        await tester.tap(find.byType(CoursesRowItemWidget));
+        await tester.pumpAndSettle();
+      });
+
+  testWidgets(
+      'coursesRowItemWidget should not throw when data and onTap are null',
+          (WidgetTester tester) async {
+        var testingWidget = WidgetTestUtil.wrapWidgetForTesting(
+            child: CoursesRowItemWidget(data: null, onTap: null));
+        await tester.pumpWidget(testingWidget);
+        await tester.tap(find.byType(CoursesRowItemWidget));
+        await tester.pumpAndSettle();
+      });
+
+  testWidgets(
+      'coursesRowItemWidget should not throw when tapping on loading widget',
+          (WidgetTester tester) async {
+        var testingWidget = WidgetTestUtil.wrapWidgetForTesting(
+            child: CoursesRowItemWidget.waiting());
+        await tester.pumpWidget(testingWidget);
+        await tester.tap(find.byType(CoursesRowItemWidget));
+        await tester.pumpAndSettle();
+      });
+}

--- a/test/widgets/home/daily_message_item_widget_test.dart
+++ b/test/widgets/home/daily_message_item_widget_test.dart
@@ -1,0 +1,29 @@
+import 'package:Medito/network/home/daily_message_response.dart';
+import 'package:Medito/widgets/home/daily_message_item_widget.dart';
+import 'package:flutter_markdown/flutter_markdown.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import '../WidgetTestUtil.dart';
+
+void main() {
+  var testData;
+
+  setUp(() {
+    testData = DailyMessageResponse(data: Data(title: 'test_title', body: 'test_body'));
+  });
+
+  testWidgets('dailyMessageItemWidget should have title and MarkdownBody',
+      (WidgetTester tester) async {
+    var testingWidget = WidgetTestUtil.wrapWidgetForTesting(
+        child: DailyMessageItemWidget(data: testData));
+
+    await tester.pumpWidget(testingWidget);
+
+    var title = find.text('test_title');
+    expect(title, findsOneWidget);
+
+    var body = find.byType(MarkdownBody);
+    expect(body, findsOneWidget);
+  });
+
+}

--- a/test/widgets/home/loading_text_box_widget.dart
+++ b/test/widgets/home/loading_text_box_widget.dart
@@ -1,0 +1,22 @@
+import 'package:Medito/widgets/home/loading_text_box_widget.dart';
+import 'package:flutter/cupertino.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  testWidgets('loadingTextBox should have configurable height',
+      (WidgetTester tester) async {
+    var loadingTextBox = LoadingTextBoxWidget(height: 10);
+    await tester.pumpWidget(loadingTextBox);
+    expect(loadingTextBox.height, 10);
+  });
+
+  testWidgets('loadingTextBox should have clipRRect and Container',
+      (WidgetTester tester) async {
+    var loadingTextBox = LoadingTextBoxWidget(height: 10);
+    await tester.pumpWidget(loadingTextBox);
+    var clipRRect = find.byType(ClipRRect);
+    var container = find.byType(Container);
+    expect(clipRRect, findsOneWidget);
+    expect(container, findsOneWidget);
+  });
+}


### PR DESCRIPTION
## Problem
I noticed that on cold start, there is a switching moment between loading widgets to the real widgets after getting network data. However, the animation is not smooth and has a stretch circular loading indicator in daily_message_widget. It might not be noticeable on powerful devices with fast network but on slow devices+network (e.g. emulator), it would be very prominent. Here is the comparison before and after my fix:
Before: 
![before](https://user-images.githubusercontent.com/11023947/119255039-e3cae180-bbb9-11eb-825d-5ceca3d3a2c4.gif)

After: 
![after](https://user-images.githubusercontent.com/11023947/119255051-eb8a8600-bbb9-11eb-832c-e9846f8f14d0.gif)

## Changes
- Extract `courses_row_item_widget`, `daily_message_item_widget`, `loading_text_box_widget`
- Align the size of loading widgets and real widgets as close as possible
- Add some basic tests for them
- Use AnimationSwitcher to switch between loading and real widget 

