### PR TITLE
Fix: Show empty state on downloads screen once all downloads are removed

### DIFF
--- a/lib/widgets/btm_nav/downloads_widget.dart
+++ b/lib/widgets/btm_nav/downloads_widget.dart
@@ -40,22 +40,20 @@ class _DownloadsListWidgetState extends State<DownloadsListWidget>
         hasCloseButton: true,
       ),
       key: scaffoldKey,
-      body: _getDownloadList(),
+      body: _downloadList.isEmpty
+      ?  _getEmptyWidget()
+      : _getDownloadList(),
     );
   }
 
   Widget _getDownloadList() {
-    if (_downloadList.isEmpty) {
-      return _getEmptyWidget();
-    } else {
-      return ListView.builder(
-          padding: EdgeInsets.symmetric(vertical: 8),
-          itemCount: _downloadList.length,
-          itemBuilder: (context, i) {
-            var item = _downloadList[i];
-            return _getSlidingItem(item, context);
-          });
-    }
+    return ListView.builder(
+        padding: EdgeInsets.symmetric(vertical: 8),
+        itemCount: _downloadList.length,
+        itemBuilder: (context, i) {
+          var item = _downloadList[i];
+          return _getSlidingItem(item, context);
+        });
   }
 
   Widget _getEmptyWidget() => EmptyStateWidget(
@@ -80,6 +78,7 @@ class _DownloadsListWidgetState extends State<DownloadsListWidget>
             if (mounted) {
               _downloadList.removeWhere((element) => element == item);
               DownloadsBloc.removeSessionFromDownloads(context, item);
+              setState(() {});
             }
 
             createSnackBar(


### PR DESCRIPTION
## Please keep in mind that I'm totally new to Dart, Flutter, and the Medito app. This is my first PR here 😬 

Related to issue https://github.com/meditohq/medito-app/issues/155

From what I could see the app state was not being reset after a download was removed from the `_downloadList` so neither `_refreshDownloadList()` nor `_downloadList.isEmpty` was ever hit again. 

I'm not sure if I have the best approach for this, but for this change I added a `setState` right after the download is removed from the `DownloadsBloc` and that fixes the issue.

While I was at it I refactored where `_downloadList.isEmpty` is checked and then call either `_getEmptyWidget()` or _getDownloadList()` accordingly. In my opinion this is a bit cleaner since it extracts that logic out of `_getDownloadList()`, making it have one less concern.

Here's what the new functionality looks like:


![Medito-Download-Screen](https://user-images.githubusercontent.com/32461613/121605957-51c93280-ca1b-11eb-9d9a-517008d205c1.gif)



