### PR TITLE
fix: select current saved background sound in background sheet

### DIFF
--- a/lib/widgets/player/background_sounds_sheet_widget.dart
+++ b/lib/widgets/player/background_sounds_sheet_widget.dart
@@ -68,7 +68,8 @@ class _ChooseBackgroundSoundDialogState
       volume = await retrieveSavedBgVolume();
       _dragBgVolumeSubject.add(volume);
       await AudioService.customAction(SET_BG_SOUND_VOL, volume / 100);
-      await AudioService.customAction(SEND_BG_SOUND);
+      var savedBgSoundName = await getBgSoundNameFromSharedPrefs();
+      await AudioService.customAction(SEND_BG_SOUND, savedBgSoundName);
     }
   }
 


### PR DESCRIPTION
Currently the background is saved and played correctly but it is not reflected when open the background bottom sheet.
This PR fixes it.