### PR TITLE
Feature: Reordering of downloaded sessions

### DIFF
--- a/lib/network/downloads/downloads_bloc.dart
+++ b/lib/network/downloads/downloads_bloc.dart
@@ -81,4 +81,13 @@ class DownloadsBloc {
     list.remove(jsonEncode(mediaFile));
     await prefs.setStringList(savedFilesKey, list);
   }
+
+  // This method is used to save the updated order of the list of downloaded sessions
+  /// Saves a given `List` of `MediaItem` elements (downloaded sessions)
+  static Future<void> saveDownloads(List<MediaItem> mediaList) async {
+    var prefs = await SharedPreferences.getInstance();
+    var list =
+        mediaList.map((MediaItem mediaItem) => jsonEncode(mediaItem)).toList();
+    await prefs.setStringList(savedFilesKey, list);
+  }
 }


### PR DESCRIPTION
This PR adresses the issue #157.
As discussed in the comments this may serve as a first iteration, where the reordering is done by long pressing on a list item and then dragging the floating item to the wanted position. The [ReorderableListView](https://api.flutter.dev/flutter/material/ReorderableListView-class.html) widget is used to achieve this behaviour.

### The following changes were made:

Downloads widget:
- Refactored the _getDownloadList method to return a ReorderableListView
which provides the onReorder property
- This callback is called once a list item has been reordered and executes
logic to adjust the index of the reordered item
- Furthermore a method to save the new order is called

- Even though a .builder constructor is available for the ReorderableListView
widget, using it caused the Dismissible functionality of the list items to
not work anymore, thus the default constructor is used
- Therefore the itemBuilder prop has been replaced with the children prop
where the download list is mapped to a list of corresponding sliding items

- Added a ValueKey based on the MediaItems id to the outer InkWell of
the Widget returned by the _getSlidingItem method, so that the
ReorderableListView can distinguish between different list items

Downloads Bloc:
- Added a new method to save a given List of MediaItems
- This method is required to save the update order of downloaded sessions