### PR TITLE
Feature: Reordering of downloaded sessions

### DIFF
--- a/lib/network/downloads/downloads_bloc.dart
+++ b/lib/network/downloads/downloads_bloc.dart
@@ -80,4 +80,13 @@ class DownloadsBloc {
     list.removeWhere((element) => MediaItem.fromJson(jsonDecode(element)).id == mediaFile.id);
     await prefs.setStringList(savedFilesKey, list);
   }
+
+  // This method is used to save the updated order of the list of downloaded sessions
+  /// Saves a given `List` of `MediaItem` elements (downloaded sessions)
+  static Future<void> saveDownloads(List<MediaItem> mediaList) async {
+    var prefs = await SharedPreferences.getInstance();
+    var list =
+        mediaList.map((MediaItem mediaItem) => jsonEncode(mediaItem)).toList();
+    await prefs.setStringList(savedFilesKey, list);
+  }
 }

--- a/lib/widgets/btm_nav/downloads_widget.dart
+++ b/lib/widgets/btm_nav/downloads_widget.dart
@@ -40,20 +40,29 @@ class _DownloadsListWidgetState extends State<DownloadsListWidget>
         hasCloseButton: true,
       ),
       key: scaffoldKey,
-      body: _downloadList.isEmpty
-      ?  _getEmptyWidget()
-      : _getDownloadList(),
+      body: _downloadList.isEmpty ? _getEmptyWidget() : _getDownloadList(),
     );
   }
 
   Widget _getDownloadList() {
-    return ListView.builder(
-        padding: EdgeInsets.symmetric(vertical: 8),
-        itemCount: _downloadList.length,
-        itemBuilder: (context, i) {
-          var item = _downloadList[i];
-          return _getSlidingItem(item, context);
+    // In order for the Dismissible action still to work on the list items,
+    // the default ReorderableListView is used (instead of the .builder one)
+    return ReorderableListView(
+      padding: EdgeInsets.symmetric(vertical: 8),
+      onReorder: (int oldIndex, int newIndex) {
+        setState(() {
+          if (oldIndex < newIndex) {
+            newIndex -= 1;
+          }
+          var reorderedItem = _downloadList.removeAt(oldIndex);
+          _downloadList.insert(newIndex, reorderedItem);
+          // To ensure, that the new list order is saved
+          DownloadsBloc.saveDownloads(_downloadList);
         });
+      },
+      children:
+          _downloadList.map((item) => _getSlidingItem(item, context)).toList(),
+    );
   }
 
   Widget _getEmptyWidget() => EmptyStateWidget(
@@ -67,6 +76,8 @@ class _DownloadsListWidgetState extends State<DownloadsListWidget>
 
   Widget _getSlidingItem(MediaItem item, BuildContext context) {
     return InkWell(
+      // This (additional) key is required in order for the ReorderableListView to distinguish between the different list items
+      key: ValueKey(item.id),
       onTap: () {
         _openPlayer(item, context);
       },


### PR DESCRIPTION
This PR adresses the issue #157 (again, as this the second PR covering this issue)
As discussed in the comments this may serve as a first iteration, where the reordering is done by long pressing on a list item and then dragging the floating item to the wanted position. The ReorderableListView widget is used to achieve this behaviour.

**The following changes were made:**

_Downloads widget:_
- Refactored the _getDownloadList method to return a ReorderableListView
which provides the onReorder property
- This callback is called once a list item has been reordered and executes
logic to adjust the index of the reordered item
- Furthermore a method to save the new order is called

- Even though a .builder constructor is available for the ReorderableListView
widget, using it caused the Dismissible functionality of the list items to
not work anymore, thus the default constructor is used
- Therefore the itemBuilder prop has been replaced with the children prop
where the download list is mapped to a list of corresponding sliding items

- Added a ValueKey based on the MediaItems id to the outer InkWell of
the Widget returned by the _getSlidingItem method, so that the
ReorderableListView can distinguish between different list items

_Downloads Bloc:_
- Added a new method to save a given List of MediaItems
- This method is required to save the update order of downloaded sessions