### PR TITLE
flutter analyze warnings reduced to inhouse Deprecated tags

### DIFF
--- a/lib/network/api_response.dart
+++ b/lib/network/api_response.dart
@@ -16,15 +16,22 @@ along with Medito App. If not, see <https://www.gnu.org/licenses/>.*/
 import 'package:equatable/equatable.dart';
 
 class ApiResponse<T> extends Equatable {
-  late final Status status;
-  T? body;
-  String? message = '';
+  final Status status;
+  final T? body;
+  final String? message;
 
-  ApiResponse.loading() : status = Status.LOADING;
-  ApiResponse.completed(this.body) : status = Status.COMPLETED;
-  ApiResponse.error(this.message) : status = Status.ERROR;
+  ApiResponse.loading()
+      : status = Status.LOADING,
+        body = null,
+        message = '';
+  ApiResponse.completed(this.body)
+      : status = Status.COMPLETED,
+        message = '';
+  ApiResponse.error(this.message)
+      : status = Status.ERROR,
+        body = null;
 
-  bool hasData(){
+  bool hasData() {
     return status != Status.LOADING && body != null;
   }
 

--- a/lib/network/packs/announcement_response.dart
+++ b/lib/network/packs/announcement_response.dart
@@ -26,11 +26,13 @@ class AnnouncementResponse {
   }
 
   Map<String, dynamic> toJson() {
-    final data = <String, dynamic>{};
+    final json = <String, dynamic>{};
+    final data = this.data;
     if (data != null) {
-      data['data'] = this.data?.toJson();
+      json['data'] = data.toJson();
     }
-    return data;
+
+    return json;
   }
 }
 
@@ -44,15 +46,7 @@ class Data {
   String? timestamp;
   String? id;
 
-  Data(
-      {icon,
-      colorPrimary,
-      body,
-      buttonLabel,
-      buttonType,
-      buttonPath,
-      timestamp,
-      id});
+  Data({icon, colorPrimary, body, buttonLabel, buttonType, buttonPath, timestamp, id});
 
   Data.fromJson(Map<String, dynamic> json) {
     icon = json['icon'];

--- a/lib/view_model/player/audio_position_viewmodel.dart
+++ b/lib/view_model/player/audio_position_viewmodel.dart
@@ -1,5 +1,4 @@
 import 'package:Medito/view_model/audio_player/audio_player_viewmodel.dart';
-import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 part 'audio_position_viewmodel.g.dart';
 
@@ -30,8 +29,7 @@ void skipAudio(
 
 final audioPositionProvider = StreamProvider.autoDispose<int>((ref) {
   final audioPlayer = ref.watch(audioPlayerNotifierProvider);
-  return audioPlayer.sessionAudioPlayer.positionStream
-      .map((position) => position.inMilliseconds);
+  return audioPlayer.sessionAudioPlayer.positionStream.map((position) => position.inMilliseconds);
 });
 
 enum SKIP_AUDIO { SKIP_FORWARD_30, SKIP_BACKWARD_10 }

--- a/lib/views/player/components/duration_indicatior_component.dart
+++ b/lib/views/player/components/duration_indicatior_component.dart
@@ -11,51 +11,44 @@ class DurationIndicatorComponent extends ConsumerWidget {
   final SessionFilesModel file;
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final audioPlayerPositionProvider = ref.watch(audioPositionProvider.stream);
-    final audioPlayer = ref
-        .watch(audioPlayerNotifierProvider.notifier)
-        .sessionAudioPlayer
-        .duration;
+    final audioPlayerPositionProvider = ref.watch(audioPositionProvider);
     return Padding(
       padding: const EdgeInsets.symmetric(horizontal: 15),
-      child: StreamBuilder<int?>(
-          stream: audioPlayerPositionProvider,
-          builder: (context, snapshot) {
-            if (snapshot.hasData && snapshot.data != null) {
-              var currentDuration = snapshot.data ?? 0;
+      child: audioPlayerPositionProvider.when(
+        error: (error, stackTrace) => SizedBox(),
+        loading: () => SizedBox(),
+        data: (data) {
+          var currentDuration = data;
 
-              return Column(
-                children: [
-                  _durationLabels(context, file.duration, currentDuration),
-                  SliderTheme(
-                    data: SliderThemeData(
-                      trackHeight: 8,
-                      trackShape: CustomTrackShape(),
-                      thumbShape: RoundSliderThumbShape(
-                        enabledThumbRadius: 5.0,
-                      ),
-                    ),
-                    child: Slider(
-                      min: 0.0,
-                      activeColor: ColorConstants.walterWhite,
-                      inactiveColor: ColorConstants.greyIsTheNewGrey,
-                      max: file.duration.toDouble() + 300,
-                      value: currentDuration.toDouble(),
-                      onChanged: (value) {
-                        ref.read(slideAudioPositionProvider(
-                            duration: value.toInt()));
-                      },
-                      onChangeEnd: (value) {
-                        ref.read(slideAudioPositionProvider(
-                            duration: value.toInt()));
-                      },
-                    ),
+          return Column(
+            children: [
+              _durationLabels(context, file.duration, currentDuration),
+              SliderTheme(
+                data: SliderThemeData(
+                  trackHeight: 8,
+                  trackShape: CustomTrackShape(),
+                  thumbShape: RoundSliderThumbShape(
+                    enabledThumbRadius: 5.0,
                   ),
-                ],
-              );
-            }
-            return SizedBox();
-          }),
+                ),
+                child: Slider(
+                  min: 0.0,
+                  activeColor: ColorConstants.walterWhite,
+                  inactiveColor: ColorConstants.greyIsTheNewGrey,
+                  max: file.duration.toDouble() + 300,
+                  value: currentDuration.toDouble(),
+                  onChanged: (value) {
+                    ref.read(slideAudioPositionProvider(duration: value.toInt()));
+                  },
+                  onChangeEnd: (value) {
+                    ref.read(slideAudioPositionProvider(duration: value.toInt()));
+                  },
+                ),
+              ),
+            ],
+          );
+        },
+      ),
     );
   }
 
@@ -84,8 +77,10 @@ class DurationIndicatorComponent extends ConsumerWidget {
   ) {
     return Text(
       label,
-      style: Theme.of(context).textTheme.titleSmall?.copyWith(
-          color: ColorConstants.walterWhite, fontFamily: DmMono, fontSize: 14),
+      style: Theme.of(context)
+          .textTheme
+          .titleSmall
+          ?.copyWith(color: ColorConstants.walterWhite, fontFamily: DmMono, fontSize: 14),
     );
   }
 }


### PR DESCRIPTION
Opened new pull request because last one had unnecessary changes.

Now the only warnings output from `flutter analyze --no-fatal-warnings --no-fatal-infos .` are from in-house Deprecated tags. These tags say things like "data' is deprecated and shouldn't be used. use fields instead" (found in `lib/network/packs/announcement_response.data`), does this mean the only change is to rename the `data` variable to `field` and fix any other issues that come up after doing that? 