### PR TITLE
fix: background sound initial state set to none

### DIFF
--- a/lib/views/background_sound/widgets/sound_listtile_widget.dart
+++ b/lib/views/background_sound/widgets/sound_listtile_widget.dart
@@ -12,7 +12,9 @@ class SoundListTileWidget extends ConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     final bgSoundNotifierProvider = ref.watch(backgroundSoundsNotifierProvider);
     final audioPlayerNotifier = ref.watch(audioPlayerNotifierProvider);
-    var isSelected = bgSoundNotifierProvider.selectedBgSound?.id == sound.id;
+    var selectedSoundId = bgSoundNotifierProvider.selectedBgSound?.id;
+    var id = selectedSoundId ?? '0';
+    var isSelected = id == sound.id;
 
     return InkWell(
       onTap: () => _handleItemTap(


### PR DESCRIPTION
["None" is not selected by default (Backgroud sounds)#527](https://github.com/meditohq/medito-app/issues/527)