### PR TITLE
Remove license header

### DIFF
--- a/lib/constants/colors/color_constants.dart
+++ b/lib/constants/colors/color_constants.dart
@@ -1,18 +1,3 @@
-/*This file is part of Medito App.
-
-Medito App is free software: you can redistribute it and/or modify
-it under the terms of the Affero GNU General Public License as published by
-the Free Software Foundation, either version 3 of the License, or
-(at your option) any later version.
-
-Medito App is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-Affero GNU General Public License for more details.
-
-You should have received a copy of the Affero GNU General Public License
-along with Medito App. If not, see <https://www.gnu.org/licenses/>.*/
-
 import 'package:flutter/material.dart';
 
 class ColorConstants {

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,17 +1,3 @@
-/*This file is part of Medito App.
-
-Medito App is free software: you can redistribute it and/or modify
-it under the terms of the Affero GNU General Public License as published by
-the Free Software Foundation, either version 3 of the License, or
-(at your option) any later version.
-
-Medito App is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-Affero GNU General Public License for more details.
-
-You should have received a copy of the Affero GNU General Public License
-along with Medito App. If not, see <https://www.gnu.org/licenses/>.*/
 import 'dart:async';
 import 'dart:io';
 

--- a/lib/services/network/api_response.dart
+++ b/lib/services/network/api_response.dart
@@ -1,18 +1,3 @@
-/*This file is part of Medito App.
-
-Medito App is free software: you can redistribute it and/or modify
-it under the terms of the Affero GNU General Public License as published by
-the Free Software Foundation, either version 3 of the License, or
-(at your option) any later version.
-
-Medito App is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-Affero GNU General Public License for more details.
-
-You should have received a copy of the Affero GNU General Public License
-along with Medito App. If not, see <https://www.gnu.org/licenses/>.*/
-
 import 'package:equatable/equatable.dart';
 
 class ApiResponse<T> extends Equatable {

--- a/lib/utils/utils.dart
+++ b/lib/utils/utils.dart
@@ -1,18 +1,3 @@
-/*This file is part of Medito App.
-
-Medito App is free software: you can redistribute it and/or modify
-it under the terms of the Affero GNU General Public License as published by
-the Free Software Foundation, either version 3 of the License, or
-(at your option) any later version.
-
-Medito App is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-Affero GNU General Public License for more details.
-
-You should have received a copy of the Affero GNU General Public License
-along with Medito App. If not, see <https://www.gnu.org/licenses/>.*/
-
 import 'dart:async';
 import 'dart:io';
 import 'dart:typed_data';

--- a/lib/views/downloads/widgets/download_list_item.dart
+++ b/lib/views/downloads/widgets/download_list_item.dart
@@ -1,18 +1,3 @@
-/*This file is part of Medito App.
-
-Medito App is free software: you can redistribute it and/or modify
-it under the terms of the Affero GNU General Public License as published by
-the Free Software Foundation, either version 3 of the License, or
-(at your option) any later version.
-
-Medito App is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-Affero GNU General Public License for more details.
-
-You should have received a copy of the Affero GNU General Public License
-along with Medito App. If not, see <https://www.gnu.org/licenses/>.*/
-
 import 'package:medito/utils/utils.dart';
 import 'package:medito/widgets/widgets.dart';
 import 'package:flutter/material.dart';

--- a/lib/widgets/headers/medito_app_bar_small.dart
+++ b/lib/widgets/headers/medito_app_bar_small.dart
@@ -1,18 +1,3 @@
-/*This file is part of Medito App.
-
-Medito App is free software: you can redistribute it and/or modify
-it under the terms of the Affero GNU General Public License as published by
-the Free Software Foundation, either version 3 of the License, or
-(at your option) any later version.
-
-Medito App is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-Affero GNU General Public License for more details.
-
-You should have received a copy of the Affero GNU General Public License
-along with Medito App. If not, see <https://www.gnu.org/licenses/>.*/
-
 import 'package:medito/constants/constants.dart';
 import 'package:flutter/material.dart';
 


### PR DESCRIPTION
The license header is only applied to a small handful of the files in the project, so this PR removes those headers to keep things simple and consistent. The license in the repository root is sufficient, there are lots of larger projects (for example, [the rust compiler and standard library](https://github.com/rust-lang/rust/blob/master/library/std/src/lib.rs)) that don't have a header in each file so it should be fine to just keep the one copy in the repository and get rid of the headers.