### PR TITLE
Fix DND silencing meditation audio on Samsung devices

### DIFF
--- a/lib/providers/dnd_provider.dart
+++ b/lib/providers/dnd_provider.dart
@@ -52,7 +52,7 @@ class DndNotifier extends Notifier<bool> {
       final hasAccess = await _dndPlugin.isNotificationPolicyAccessGranted();
       if (hasAccess && state) {
         await _dndPlugin.setInterruptionFilter(
-          enable ? InterruptionFilter.priority : InterruptionFilter.all,
+          enable ? InterruptionFilter.alarms : InterruptionFilter.all,
         );
       }
     } catch (e) {


### PR DESCRIPTION
Switch InterruptionFilter from priority to alarms mode. Samsung One UI's
priority DND mode can mute USAGE_MEDIA audio streams depending on device
settings, causing no audio during meditation sessions.

https://claude.ai/code/session_01XFwTrfGDRk55XfHTPPBKYd