### PR TITLE
fix(release): keep pubspec at 3-part version and auto-bump build number

### DIFF
--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -8,7 +8,7 @@ Cut a new release of the Medito app. Follow the steps below in order — each st
 
 ## 1. Decide the new version
 
-Version names are **date-based**: `YY.M.D` (two-digit year, unpadded month, unpadded day — e.g. today's release would be `26.4.22`). If a release already exists for today, the script appends `.N` starting at `.1` (e.g. `26.4.22.1`, then `.2`, etc.).
+Version names are **date-based**: `YY.M.D` (two-digit year, unpadded month, unpadded day — e.g. today's release would be `26.4.22`). The pubspec version is **always** the bare 3-part date — Flutter rejects 4-part versions. If a release already exists for today, the pubspec version stays unchanged and the new commit is tagged with a `-rN` suffix (e.g. `26.4.22-r2`, then `-r3`, etc.). App stores distinguish re-cuts by the build number, which the script bumps automatically.
 
 You no longer compute the version yourself or pass `$ARGUMENTS` through — `prepare_release.sh` derives it from `date` and existing git tags in step 4. If the user passed an explicit version in `$ARGUMENTS`, tell them the script now auto-derives and ask whether they actually want to override; only proceed with `--force` if they confirm.
 
@@ -18,7 +18,7 @@ Before continuing, fetch tags so the script sees what's already shipped:
 git fetch --tags
 ```
 
-If the latest existing tag is ahead of today's date (e.g. last tag is `26.5.6` but today is `26.5.2`), the script will refuse to run without `--force`. That's the drift detector — surface the message to the user verbatim and only re-run with `--force` after explicit approval. With `--force` the script keeps the latest tag's date as the base and bumps the `.N` suffix.
+If the latest existing tag is ahead of today's date (e.g. last tag is `26.5.6` but today is `26.5.2`), the script will refuse to run without `--force`. That's the drift detector — surface the message to the user verbatim and only re-run with `--force` after explicit approval. With `--force` the script keeps the latest tag's date as the base and adds a `-rN` re-cut suffix to the tag.
 
 Tell the user that the version will be derived in step 4 before doing anything destructive.
 
@@ -50,7 +50,7 @@ After that skill finishes, show the user the current `Unreleased` section (e.g. 
 
 If the user wants changes, either apply them yourself based on their feedback or let them edit the file directly and confirm when ready. Only continue once they've signed off on the notes.
 
-## 4. Run prepare_release.sh and bump the build number
+## 4. Run prepare_release.sh
 
 From the project root:
 
@@ -59,26 +59,17 @@ From the project root:
 ```
 
 This script:
-- Computes the new version from today's date and existing git tags (echoes `Computed version: <new-version>`)
+- Computes the pubspec version (always 3-part `YY.M.D`) and the git tag name (`YY.M.D` for the first cut, `YY.M.D-r2`, `-r3`, ... for same-day re-cuts) — both are echoed as `Pubspec version: <...>` and `Git tag: <...>`
 - Refuses to run if the latest tag is ahead of today's date — pass `--force` only after the user has acknowledged the drift
-- Rewrites the `version:` line in `pubspec.yaml` to `<new-version>+<existing-build>`
-- Copies the version to the clipboard
-- Moves the `Unreleased` entries in `release_notes.txt` under a new section headed with the version, leaving a fresh empty `Unreleased` at the top
+- Rewrites the `version:` line in `pubspec.yaml` to `<pubspec-version>+<bumped-build>`, incrementing the existing build integer by exactly 1
+- Copies the tag name to the clipboard
+- Moves the `Unreleased` entries in `release_notes.txt` under a new section headed with the tag name, leaving a fresh empty `Unreleased` at the top
 
-After it runs, read the new version back from `pubspec.yaml` (`grep "^version:" pubspec.yaml | sed 's/version: //' | cut -d'+' -f1`) so later steps can reference it.
+Capture both names from the script output for later steps — the **pubspec version** is what's in `pubspec.yaml` (`grep "^version:" pubspec.yaml | sed 's/version: //' | cut -d'+' -f1`), and the **tag name** is what step 7 will use. On first-of-the-day cuts they're identical; on re-cuts the tag has the `-rN` suffix.
+
+Also confirm the build number bumped (it should be exactly +1 from before — the script echoes `build <old> → <new>`).
 
 If the script prints `No unreleased notes found — nothing to do.`, stop and ask the user whether to proceed anyway — usually you want notes in a release.
-
-**Then bump the build number.** The build number (the integer after `+` in the `version:` line) must increment by exactly 1 on every release — `prepare_release.sh` preserves the existing build number, so you need to bump it yourself afterwards.
-
-```bash
-# Read current build, add 1, replace in pubspec.yaml
-OLD_BUILD=$(grep "^version:" pubspec.yaml | sed 's/version: //' | cut -d'+' -f2)
-NEW_BUILD=$((OLD_BUILD + 1))
-sed -i '' "s/^version: .*/version: <new-version>+$NEW_BUILD/" pubspec.yaml
-```
-
-Confirm the result with `grep "^version:" pubspec.yaml` before continuing. E.g. `3.6.15+302390` → `3.6.16+302391`.
 
 ## 5. Sanity-check the diff
 
@@ -93,21 +84,21 @@ Only `pubspec.yaml` and `release_notes.txt` should have changed. If anything els
 
 ## 6. Commit
 
-Stage only the two expected files and commit:
+Stage only the two expected files and commit. Use the **tag name** in the commit message so re-cuts are unambiguous:
 
 ```bash
 git add pubspec.yaml release_notes.txt
-git commit -m "chore: release <new-version>"
+git commit -m "chore: release <tag-name>"
 ```
 
 Do **not** use `git add -A` — if the pre-flight check missed something, we don't want to accidentally sweep it into the release commit.
 
 ## 7. Tag the commit
 
-Tags in this repo use bare semver (no `v` prefix — check recent tags with `git tag --sort=-creatordate | head` if unsure). Tag the commit you just made:
+Tags in this repo use bare semver / date format (no `v` prefix — check recent tags with `git tag --sort=-creatordate | head` if unsure). Tag the commit you just made with the **tag name** echoed by the script:
 
 ```bash
-git tag <new-version>
+git tag <tag-name>
 ```
 
 ## 8. Push
@@ -116,7 +107,7 @@ Push the branch and the tag to origin:
 
 ```bash
 git push
-git push origin <new-version>
+git push origin <tag-name>
 ```
 
 ## 9. Choose deploy tracks and dispatch the workflow
@@ -130,7 +121,7 @@ Then trigger the workflow against the new tag with the chosen inputs:
 
 ```bash
 gh workflow run release.yml \
-  --ref <new-version> \
+  --ref <tag-name> \
   -f android_internal=<true|false> \
   -f android_production=<true|false> \
   -f ios_testflight=<true|false> \
@@ -146,7 +137,7 @@ After dispatching, surface the run URL with `gh run list --workflow=release.yml 
 ## 10. Report back
 
 Tell the user concisely:
-- The version that was released
+- The pubspec version and tag name (mention the tag name only if it differs from the pubspec version, e.g. on a re-cut)
 - The commit SHA that was tagged
 - That the tag has been pushed
 - Which tracks were dispatched (or that no build was kicked off)

--- a/prepare_release.sh
+++ b/prepare_release.sh
@@ -37,32 +37,24 @@ cmp_date() {
 
 TODAY="$(date +%y.%-m.%-d)"
 
-# Find the latest date-shaped tag by numeric tuple — sort -V handles this for
-# tags whose components are pure integers (no .N suffix mixed in), but we walk
-# every tag manually to be safe across the YY.M.D and YY.M.D.N shapes.
+# Find the most recent date-shaped tag. Only the YY.M.D portion drives the
+# drift detector — any re-cut suffix (legacy .N or current -rN) is stripped.
 LATEST_TAG=""
-LATEST_KEY=""
+LATEST_DATE=""
+LATEST_DATE_KEY=""
 while IFS= read -r tag; do
     [ -z "$tag" ] && continue
-    # Skip tags that don't match the strict YY.M.D[.N] shape (older tags
-    # sometimes carry +build or platform suffixes — we only care about clean
-    # date-shaped tags here).
-    [[ "$tag" =~ ^[0-9]+\.[0-9]+\.[0-9]+(\.[0-9]+)?$ ]] || continue
-    # Build a zero-padded sort key: YYY MMM DDD NNN
-    IFS=. read -r ty tm td tn <<<"$tag"
-    [ -z "$tn" ] && tn=0
-    key=$(printf "%03d%03d%03d%03d" "$ty" "$tm" "$td" "$tn")
-    if [ -z "$LATEST_KEY" ] || [ "$key" \> "$LATEST_KEY" ]; then
-        LATEST_KEY="$key"
+    [[ "$tag" =~ ^([0-9]+)\.([0-9]+)\.([0-9]+)(\.[0-9]+|-r[0-9]+)?$ ]] || continue
+    ty="${BASH_REMATCH[1]}"
+    tm="${BASH_REMATCH[2]}"
+    td="${BASH_REMATCH[3]}"
+    key=$(printf "%03d%03d%03d" "$ty" "$tm" "$td")
+    if [ -z "$LATEST_DATE_KEY" ] || [ "$key" \> "$LATEST_DATE_KEY" ]; then
+        LATEST_DATE_KEY="$key"
+        LATEST_DATE="${ty}.${tm}.${td}"
         LATEST_TAG="$tag"
     fi
 done < <(git tag --list '[0-9]*.[0-9]*.[0-9]*')
-
-if [ -n "$LATEST_TAG" ]; then
-    LATEST_DATE="$(echo "$LATEST_TAG" | cut -d. -f1-3)"
-else
-    LATEST_DATE=""
-fi
 
 # Decide BASE date for the new version.
 if [ -z "$LATEST_DATE" ]; then
@@ -73,7 +65,7 @@ else
             if [ "$FORCE" -ne 1 ]; then
                 echo "✗ Latest tag $LATEST_TAG is ahead of today ($TODAY)." >&2
                 echo "  This usually means a previous release used the wrong date." >&2
-                echo "  Rerun with --force to add a same-day suffix on top of $LATEST_DATE." >&2
+                echo "  Rerun with --force to add a re-cut suffix on top of $LATEST_DATE." >&2
                 exit 1
             fi
             BASE="$LATEST_DATE"
@@ -87,50 +79,62 @@ else
     esac
 fi
 
-# Find the next .N suffix for BASE. No suffix counts as 0; first reissue is .1.
-MAX_SUFFIX=-1
+# Count prior cuts for BASE so the new tag picks the next index:
+#   BASE itself      → cut #1
+#   BASE.N (legacy)  → cut #(N+1)   — e.g. 26.5.2.1 was the 2nd cut of 26.5.2
+#   BASE-rN          → cut #N
+# The pubspec version is always the 3-part BASE; the re-cut index lives on
+# the git tag only, since Flutter rejects 4-part pubspec versions.
+HIGHEST_CUT=0
+base_re="${BASE//./\\.}"
 while IFS= read -r tag; do
     [ -z "$tag" ] && continue
     if [ "$tag" = "$BASE" ]; then
-        n=0
+        idx=1
+    elif [[ "$tag" =~ ^${base_re}\.([0-9]+)$ ]]; then
+        idx=$(( ${BASH_REMATCH[1]} + 1 ))
+    elif [[ "$tag" =~ ^${base_re}-r([0-9]+)$ ]]; then
+        idx="${BASH_REMATCH[1]}"
     else
-        n="${tag#${BASE}.}"
-        case "$n" in
-            ''|*[!0-9]*) continue ;;
-        esac
+        continue
     fi
-    if [ "$n" -gt "$MAX_SUFFIX" ]; then
-        MAX_SUFFIX="$n"
+    if [ "$idx" -gt "$HIGHEST_CUT" ]; then
+        HIGHEST_CUT="$idx"
     fi
-done < <(git tag --list "${BASE}" "${BASE}.*")
+done < <(git tag --list "${BASE}" "${BASE}.*" "${BASE}-r*")
 
-if [ "$MAX_SUFFIX" -lt 0 ]; then
-    NEW_VERSION="$BASE"
+NEXT_CUT=$(( HIGHEST_CUT + 1 ))
+PUBSPEC_VERSION="$BASE"
+if [ "$NEXT_CUT" -eq 1 ]; then
+    TAG_NAME="$BASE"
 else
-    NEW_VERSION="${BASE}.$((MAX_SUFFIX + 1))"
+    TAG_NAME="${BASE}-r${NEXT_CUT}"
 fi
 
-if ! [[ "$NEW_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+(\.[0-9]+)?$ ]]; then
-    echo "✗ Computed version $NEW_VERSION does not match expected shape" >&2
+if ! [[ "$PUBSPEC_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+    echo "✗ Computed pubspec version $PUBSPEC_VERSION does not match expected shape" >&2
     exit 1
 fi
 
-if [ -n "$(git tag -l "$NEW_VERSION")" ]; then
-    echo "✗ Tag $NEW_VERSION already exists — refusing to overwrite" >&2
+if [ -n "$(git tag -l "$TAG_NAME")" ]; then
+    echo "✗ Tag $TAG_NAME already exists — refusing to overwrite" >&2
     exit 1
 fi
 
-echo "✓ Computed version: $NEW_VERSION"
+echo "✓ Pubspec version: $PUBSPEC_VERSION"
+echo "✓ Git tag:         $TAG_NAME"
 
-BUILD_NUMBER=$(grep "^version:" "$PUBSPEC" | sed 's/version: //' | cut -d'+' -f2)
-sed -i '' "s/^version: .*/version: $NEW_VERSION+$BUILD_NUMBER/" "$PUBSPEC"
-echo "✓ pubspec.yaml updated to $NEW_VERSION+$BUILD_NUMBER"
+# Bump the build number — app stores require a monotonic build integer.
+OLD_BUILD=$(grep "^version:" "$PUBSPEC" | sed 's/version: //' | cut -d'+' -f2)
+NEW_BUILD=$((OLD_BUILD + 1))
+sed -i '' "s/^version: .*/version: ${PUBSPEC_VERSION}+${NEW_BUILD}/" "$PUBSPEC"
+echo "✓ pubspec.yaml updated to ${PUBSPEC_VERSION}+${NEW_BUILD} (build ${OLD_BUILD} → ${NEW_BUILD})"
 
-VERSION="$NEW_VERSION"
+VERSION="$TAG_NAME"
 
-# Copy to clipboard
+# Copy the tag name to clipboard for use in commit messages, etc.
 echo -n "$VERSION" | pbcopy
-echo "✓ Version $VERSION copied to clipboard"
+echo "✓ Tag $VERSION copied to clipboard"
 
 # Reorganise release_notes.txt
 NOTES_FILE="$SCRIPT_DIR/release_notes.txt"


### PR DESCRIPTION
## Summary
- `prepare_release.sh` now always writes a 3-part `YY.M.D` to `pubspec.yaml` and encodes same-day re-cuts on the git **tag** only (`YY.M.D-r2`, `-r3`, ...). Flutter rejects 4-part pubspec versions, which has caused two failed releases (26.5.2.1 → re-cut as 26.5.3, and 26.5.13.1 → re-cut as 26.5.13).
- The script now bumps the build integer (`+NNN`) itself when it rewrites `pubspec.yaml`. App stores key on `(version, build_number)`, so the build number is what distinguishes a re-cut from the original — no need to change the pubspec version.
- The pubspec-version regex is tightened to `^[0-9]+\.[0-9]+\.[0-9]+$` so any future 4-part computation would fail loudly instead of silently shipping.
- The tag-suffix scanner understands both the legacy `BASE.N` form (so old tags like `26.5.2.1` still count correctly) and the new `BASE-rN` form when picking the next re-cut index.
- `.claude/skills/release/SKILL.md` updates: dropped the manual build-bump step from step 4, taught steps 6/7/9 to use the script's `Git tag:` output (which can differ from the pubspec version on re-cuts), and updated step 1 to describe the new tag-suffix scheme.

## Test plan
- [x] Local checkout with `git tag 26.5.13` already present produces `Pubspec version: 26.5.13`, `Git tag: 26.5.13-r2`, and a buildable `26.5.13+302412` pubspec.
- [x] Adding a temporary `26.5.13-r2` tag promotes the next run to `-r3`.
- [x] Adding a temporary legacy `26.5.13.1` tag also promotes to `-r3` (since `.1` counted as cut #2).
- [ ] Next real release exercises the path end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)