### PR TITLE
chore: remove PAYWALL_ENV plumbing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,14 +19,6 @@ on:
         description: 'iOS – App Store draft'
         type: boolean
         default: false
-      paywall_env:
-        description: 'Paywall environment'
-        required: true
-        default: 'live'
-        type: choice
-        options:
-          - live
-          - dev
       match_readonly:
         description: 'Keep match in readonly mode (set false to refresh certs/profiles)'
         type: boolean
@@ -156,7 +148,6 @@ jobs:
           flutter build apk --flavor prod --release \
             --dart-define-from-file=.prod.json \
             --dart-define=MOCK_MODE=false \
-            --dart-define=PAYWALL_ENV=${{ inputs.paywall_env || 'live' }} \
             --obfuscate --split-debug-info=./symbols
 
       - name: Upload APK artifact
@@ -561,7 +552,6 @@ jobs:
           flutter build ios --simulator --no-codesign \
             --dart-define-from-file=.prod.json \
             --dart-define=MOCK_MODE=false \
-            --dart-define=PAYWALL_ENV=live \
             --dart-define=IS_SIMULATOR=true
 
       # Preserve the built .app so the upgrade-test job (next release) can
@@ -937,7 +927,6 @@ jobs:
       - name: Build & upload iOS release
         working-directory: ios
         env:
-          PAYWALL_ENV: ${{ inputs.paywall_env || 'live' }}
           MATCH_READONLY: ${{ github.event_name == 'workflow_dispatch' && inputs.match_readonly || false }}
           FASTLANE_XCODEBUILD_SETTINGS_TIMEOUT: '120'
           FASTLANE_XCODEBUILD_SETTINGS_RETRIES: '8'

--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -147,7 +147,6 @@ jobs:
           flutter build apk --flavor prod --release \
             --dart-define-from-file=.prod.json \
             --dart-define=MOCK_MODE=false \
-            --dart-define=PAYWALL_ENV=live \
             --obfuscate --split-debug-info=./symbols
 
       - name: Enable KVM
@@ -328,7 +327,6 @@ jobs:
           flutter build ios --simulator --no-codesign \
             --dart-define-from-file=.prod.json \
             --dart-define=MOCK_MODE=false \
-            --dart-define=PAYWALL_ENV=live \
             --dart-define=IS_SIMULATOR=true
 
       - name: Boot iOS simulator

--- a/.mock.json
+++ b/.mock.json
@@ -7,7 +7,6 @@
   "EDIT_STATS_URL": "https://mock-stats.medito.invalid/",
   "DONATION_BASE_URL": "https://mock-donation.medito.invalid/",
   "DONATION_TOKEN": "mock-donation-token",
-  "PAYWALL_ENV": "dev",
   "FACEBOOK_APP_ID": "",
   "FACEBOOK_CLIENT_TOKEN": ""
 }

--- a/build_all.sh
+++ b/build_all.sh
@@ -69,7 +69,6 @@ elif [ "$BUILD_IOS" = true ]; then
     print_colored $BLUE "This script will build iOS app only"
 fi
 
-print_colored $BLUE "You'll choose the paywall environment below"
 echo ""
 
 # Get the current version from pubspec.yaml
@@ -93,35 +92,6 @@ if [ "$CURRENT_VERSION" = "$LAST_COMMITTED_VERSION" ]; then
     fi
 fi
 
-# Paywall environment selection
-print_colored $BLUE "🎯 Paywall Environment Selection"
-print_colored $BLUE "================================"
-echo "1) Live paywalls (for production users)"
-echo "2) Dev paywalls (for testing)"
-echo ""
-echo -n "Select paywall environment (1-2, default: 1): "
-read paywall_choice
-
-case $paywall_choice in
-    2)
-        PAYWALL_ENV="dev"
-        print_colored $YELLOW "🧪 Selected: Dev paywalls"
-        print_colored $YELLOW "⚠️  WARNING: You are building with DEV paywalls!"
-        print_colored $YELLOW "   Make sure this is for testing only, not production deployment."
-        echo ""
-        print_colored $YELLOW "Are you sure you want to continue with DEV paywalls? (y/N): "
-        read dev_confirm
-        if [[ ! "$dev_confirm" =~ ^[Yy]$ ]]; then
-            print_colored $RED "❌ Build cancelled."
-            exit 1
-        fi
-        ;;
-    *)
-        PAYWALL_ENV="live"
-        print_colored $GREEN "✅ Selected: Live paywalls"
-        ;;
-esac
-
 # Play Console upload selection (before building)
 UPLOAD_TO_PLAY_STORE=false
 PLAY_STORE_TRACK=""
@@ -135,33 +105,27 @@ if [ "$BUILD_ANDROID" = true ]; then
 
     if [[ ! "$upload_choice" =~ ^[Nn]$ ]]; then
         UPLOAD_TO_PLAY_STORE=true
-        
-        # Determine track based on paywall environment
-        if [ "$PAYWALL_ENV" = "dev" ]; then
-            PLAY_STORE_TRACK="internal"
-            print_colored $YELLOW "Will upload to 'internal' track (dev paywalls)"
-        else
-            echo ""
-            print_colored $BLUE "Select Play Console track:"
-            echo "1) internal (for internal testing)"
-            echo "2) beta (for beta testing)"
-            echo "3) production (for production release)"
-            echo ""
-            echo -n "Select track (1-3, default: 3): "
-            read track_choice
-            
-            case $track_choice in
-                1)
-                    PLAY_STORE_TRACK="internal"
-                    ;;
-                2)
-                    PLAY_STORE_TRACK="beta"
-                    ;;
-                *)
-                    PLAY_STORE_TRACK="production"
-                    ;;
-            esac
-        fi
+
+        echo ""
+        print_colored $BLUE "Select Play Console track:"
+        echo "1) internal (for internal testing)"
+        echo "2) beta (for beta testing)"
+        echo "3) production (for production release)"
+        echo ""
+        echo -n "Select track (1-3, default: 3): "
+        read track_choice
+
+        case $track_choice in
+            1)
+                PLAY_STORE_TRACK="internal"
+                ;;
+            2)
+                PLAY_STORE_TRACK="beta"
+                ;;
+            *)
+                PLAY_STORE_TRACK="production"
+                ;;
+        esac
     fi
 fi
 
@@ -210,15 +174,10 @@ android_post_build() {
     mkdir -p "$DATED_APKS_DIR"
 
     SOURCE_APK="build/app/outputs/apk/prod/release/app-prod-release.apk"
-    DEST_APK="$DATED_APKS_DIR/medito-$CURRENT_VERSION-$PAYWALL_ENV-paywall-$DATE_STAMP.apk"
+    DEST_APK="$DATED_APKS_DIR/medito-$CURRENT_VERSION-$DATE_STAMP.apk"
 
     cp "$SOURCE_APK" "$DEST_APK"
     print_colored $GREEN "✅ APK copied to $DEST_APK"
-    if [ "$PAYWALL_ENV" = "dev" ]; then
-        print_colored $YELLOW "⚠️  This build has DEV paywalls - do NOT deploy to production!"
-    else
-        print_colored $GREEN "✅ This build has LIVE paywalls - safe for production deployment"
-    fi
 
     if [ "$UPLOAD_TO_PLAY_STORE" = true ] && [ -n "$PLAY_STORE_TRACK" ]; then
         echo ""
@@ -283,9 +242,8 @@ android_post_build() {
 
 if [ "$BUILD_ANDROID" = true ]; then
     print_colored $BLUE "🚀 Starting Android build..."
-    print_colored $BLUE "Paywall environment: $PAYWALL_ENV"
 
-    flutter build apk --flavor prod --release --dart-define-from-file=../.prod.json --dart-define=PAYWALL_ENV=$PAYWALL_ENV
+    flutter build apk --flavor prod --release --dart-define-from-file=../.prod.json
 
     if [ "$BUILD_IOS" = true ]; then
         # Run Android post-build in background while iOS builds
@@ -305,9 +263,8 @@ fi
 
 if [ "$BUILD_IOS" = true ]; then
     print_colored $BLUE "🚀 Starting iOS build and upload..."
-    print_colored $BLUE "Paywall environment: $PAYWALL_ENV"
 
-    flutter build ios --dart-define-from-file=../.prod.json --dart-define=ENABLE_DEVICE_PREVIEW=false --dart-define=PAYWALL_ENV=$PAYWALL_ENV --release
+    flutter build ios --dart-define-from-file=../.prod.json --dart-define=ENABLE_DEVICE_PREVIEW=false --release
 
     ARCHIVE_PATH="build/ios/archive/Runner.xcarchive"
     EXPORT_PATH="build/ios/ipa"
@@ -336,15 +293,10 @@ if [ "$BUILD_IOS" = true ]; then
     IPA_PATH="$EXPORT_PATH/Runner.ipa"
 
     if [ -f "$IPA_PATH" ]; then
-        NEW_IPA_PATH="$EXPORT_PATH/medito-${CURRENT_VERSION}-${PAYWALL_ENV}-paywall-${DATE_STAMP}.ipa"
+        NEW_IPA_PATH="$EXPORT_PATH/medito-${CURRENT_VERSION}-${DATE_STAMP}.ipa"
         cp "$IPA_PATH" "$NEW_IPA_PATH"
-        
+
         print_colored $GREEN "✅ iOS IPA built: $NEW_IPA_PATH"
-        if [ "$PAYWALL_ENV" = "dev" ]; then
-            print_colored $YELLOW "⚠️  This build has DEV paywalls - do NOT deploy to production!"
-        else
-            print_colored $GREEN "✅ This build has LIVE paywalls - safe for production deployment"
-        fi
     else
         print_colored $RED "❌ Failed to build iOS IPA"
         exit 1
@@ -404,7 +356,6 @@ echo ""
 print_colored $GREEN "🎉 Build and Deploy Complete!"
 print_colored $GREEN "============================="
 print_colored $BLUE "Version: $CURRENT_VERSION"
-print_colored $BLUE "Paywall Environment: $PAYWALL_ENV"
 
 if [ "$BUILD_ANDROID" = true ] && [ "$BUILD_IOS" = true ]; then
     print_colored $BLUE "Platforms: Android & iOS"
@@ -415,15 +366,6 @@ elif [ "$BUILD_IOS" = true ]; then
 fi
 
 echo ""
-if [ "$PAYWALL_ENV" = "dev" ]; then
-    print_colored $YELLOW "⚠️  REMINDER: This build has DEV paywalls"
-    print_colored $YELLOW "   Safe for: TestFlight, Play Store Internal Testing"
-    print_colored $YELLOW "   NOT safe for: Production deployment"
-else
-    print_colored $GREEN "✅ This build has LIVE paywalls"
-    print_colored $GREEN "   Safe for: Production deployment"
-fi
-
 if [ "$ANDROID_BG_FAILED" = true ]; then
     echo ""
     print_colored $RED "⚠️  Android post-processing had errors — check output above"

--- a/build_apk.sh
+++ b/build_apk.sh
@@ -3,43 +3,30 @@
 # Exit on error
 set -e
 
-# Accept PAYWALL_ENV as first argument or use environment variable, default to "live"
-PAYWALL_ENV="${1:-${PAYWALL_ENV:-live}}"
-
-# Validate PAYWALL_ENV
-if [ "$PAYWALL_ENV" != "live" ] && [ "$PAYWALL_ENV" != "dev" ]; then
-  echo "❌ Invalid PAYWALL_ENV: $PAYWALL_ENV"
-  echo "Usage: $0 [live|dev]"
-  echo "   or: PAYWALL_ENV=dev $0"
-  exit 1
-fi
-
 echo "🧹 Cleaning project..."
 flutter clean
 
 # Extract version number from pubspec.yaml
 VERSION=$(grep '^version:' pubspec.yaml | awk '{print $2}' | cut -d'+' -f1)
 echo "📱 Building APK for version $VERSION..."
-echo "🎯 Paywall environment: $PAYWALL_ENV"
 
-# Build the APK with specified paywall environment
-flutter build apk --flavor prod --release --dart-define-from-file=../.prod.json --dart-define=PAYWALL_ENV=$PAYWALL_ENV
+flutter build apk --flavor prod --release --dart-define-from-file=../.prod.json
 
 # Define source and destination paths
 SOURCE_APK="build/app/outputs/apk/prod/release/app-prod-release.apk"
-  DEST_APK="build/app/outputs/apk/prod/release/medito-${VERSION}-${PAYWALL_ENV}-paywall.apk"
+DEST_APK="build/app/outputs/apk/prod/release/medito-${VERSION}.apk"
 
 # Check if the APK was built successfully
 if [ -f "$SOURCE_APK" ]; then
   echo "✅ APK built successfully"
-  
+
   # Rename the APK
   cp "$SOURCE_APK" "$DEST_APK"
-  
+
   # Get full path
   FULL_PATH="$(pwd)/$DEST_APK"
-  
-  echo "🏷️ APK renamed to medito-${VERSION}-${PAYWALL_ENV}-paywall.apk"
+
+  echo "🏷️ APK renamed to medito-${VERSION}.apk"
   echo "📂 APK location: $DEST_APK"
   echo "📂 Full path: $FULL_PATH"
 else
@@ -48,11 +35,6 @@ else
 fi
 
 echo "✨ Build process completed successfully"
-if [ "$PAYWALL_ENV" = "dev" ]; then
-  echo "⚠️  WARNING: This build has DEV paywalls - do NOT deploy to production!"
-else
-  echo "✅ This build has LIVE paywalls - safe for production deployment"
-fi
 
 # Open Finder and reveal the APK
 open -R "$DEST_APK"

--- a/build_ios.sh
+++ b/build_ios.sh
@@ -2,17 +2,6 @@
 
 set -e
 
-# Accept PAYWALL_ENV as first argument or use environment variable, default to "live"
-PAYWALL_ENV="${1:-${PAYWALL_ENV:-live}}"
-
-# Validate PAYWALL_ENV
-if [ "$PAYWALL_ENV" != "live" ] && [ "$PAYWALL_ENV" != "dev" ]; then
-  echo "\n[ERROR] Invalid PAYWALL_ENV: $PAYWALL_ENV"
-  echo "Usage: $0 [live|dev]"
-  echo "   or: PAYWALL_ENV=dev $0"
-  exit 1
-fi
-
 # Load iOS credentials if available
 if [ -f "ios_credentials.sh" ]; then
   source ios_credentials.sh
@@ -21,8 +10,7 @@ fi
 # Build the iOS app for production
 
 echo "\n[1/3] Building iOS app for production..."
-echo "🎯 Paywall environment: $PAYWALL_ENV"
-flutter build ios --dart-define-from-file=../.prod.json --dart-define=ENABLE_DEVICE_PREVIEW=false --dart-define=PAYWALL_ENV=$PAYWALL_ENV --release
+flutter build ios --dart-define-from-file=../.prod.json --dart-define=ENABLE_DEVICE_PREVIEW=false --release
 
 echo "\n[2/3] Exporting .ipa..."
 
@@ -81,12 +69,7 @@ xcrun altool --upload-app -f "$IPA_PATH" -t ios -u "$APPLE_ID" -p "$APP_PASSWORD
 
 if [ $? -eq 0 ]; then
   echo "\n[Success] .ipa uploaded to TestFlight."
-  if [ "$PAYWALL_ENV" = "dev" ]; then
-    echo "\n⚠️  WARNING: This build has DEV paywalls - do NOT deploy to production!"
-  else
-    echo "\n✅ This build has LIVE paywalls - safe for production deployment"
-  fi
 else
   echo "\n[ERROR] Upload failed."
   exit 1
-fi 
+fi

--- a/ios/fastlane/Fastfile
+++ b/ios/fastlane/Fastfile
@@ -25,8 +25,6 @@ platform :ios do
       in_house: false
     )
 
-    paywall_env = options[:paywall_env] || ENV["PAYWALL_ENV"] || "live"
-
     widget_bundle_id = fetch_profiles()
 
     Dir.chdir("..") do
@@ -35,7 +33,6 @@ platform :ios do
         "--dart-define-from-file=.prod.json " \
         "--dart-define=MOCK_MODE=false " \
         "--dart-define=ENABLE_DEVICE_PREVIEW=false " \
-        "--dart-define=PAYWALL_ENV=#{paywall_env} " \
         "--no-codesign"
       )
     end
@@ -81,7 +78,6 @@ platform :ios do
         "--dart-define-from-file=.prod.json " \
         "--dart-define=MOCK_MODE=false " \
         "--dart-define=ENABLE_DEVICE_PREVIEW=false " \
-        "--dart-define=PAYWALL_ENV=live " \
         "--no-codesign"
       )
     end

--- a/lib/constants/http/http_constants.dart
+++ b/lib/constants/http/http_constants.dart
@@ -24,7 +24,6 @@ class EnvConfig {
   final String donationBaseUrl;
   final String donationToken;
   final String paywallFormUrl;
-  final String paywallEnvironment;
   final String facebookAppId;
   final String facebookClientToken;
 
@@ -38,7 +37,6 @@ class EnvConfig {
     required this.donationBaseUrl,
     required this.donationToken,
     required this.paywallFormUrl,
-    required this.paywallEnvironment,
     required this.facebookAppId,
     required this.facebookClientToken,
   });
@@ -55,7 +53,6 @@ class ProdEnv extends EnvConfig {
     required super.donationBaseUrl,
     required super.donationToken,
     required super.paywallFormUrl,
-    required super.paywallEnvironment,
     required super.facebookAppId,
     required super.facebookClientToken,
   });
@@ -72,7 +69,6 @@ class StagingEnv extends EnvConfig {
     required super.donationBaseUrl,
     required super.donationToken,
     required super.paywallFormUrl,
-    required super.paywallEnvironment,
     required super.facebookAppId,
     required super.facebookClientToken,
   });
@@ -94,8 +90,6 @@ const _prodEnv = ProdEnv(
     'PAYWALL_URL',
     defaultValue: 'https://paywall.meditofoundation.org/',
   ),
-  paywallEnvironment:
-      String.fromEnvironment('PAYWALL_ENV', defaultValue: 'live'),
   facebookAppId: String.fromEnvironment('FACEBOOK_APP_ID'),
   facebookClientToken: String.fromEnvironment('FACEBOOK_CLIENT_TOKEN'),
 );
@@ -113,8 +107,6 @@ const _stagingEnv = StagingEnv(
     'PAYWALL_URL',
     defaultValue: 'https://test.meditofoundation.org/',
   ),
-  paywallEnvironment:
-      String.fromEnvironment('PAYWALL_ENV', defaultValue: 'dev'),
   facebookAppId: String.fromEnvironment('FACEBOOK_APP_ID'),
   facebookClientToken: String.fromEnvironment('FACEBOOK_CLIENT_TOKEN'),
 );
@@ -142,7 +134,6 @@ String get deleteAccountUrl => _currentEnv.deleteAccountBaseUrl;
 String get donationBaseUrl => _currentEnv.donationBaseUrl;
 String get donationToken => _currentEnv.donationToken;
 String get paywallFormUrl => _currentEnv.paywallFormUrl;
-String get paywallEnvironment => _currentEnv.paywallEnvironment;
 String get facebookAppId => _currentEnv.facebookAppId;
 String get facebookClientToken => _currentEnv.facebookClientToken;
 


### PR DESCRIPTION
## Summary
- `PAYWALL_ENV` was plumbed through build scripts, the iOS Fastfile, GitHub workflows, `.mock.json`, and stored on `EnvConfig` as `paywallEnvironment`, but nothing in the app, donate website, or native code ever reads the getter.
- Removes the dart-define, the workflow input + dispatch arg, the prompt in `build_all.sh`, the Fastfile option, the `.mock.json` key, and the field/getter on `EnvConfig`/`ProdEnv`/`StagingEnv`.

## Test plan
- [x] `flutter analyze` on the edited http_constants.dart — clean
- [ ] CI: release.yml + smoke-test.yml still green on this branch
- [ ] Confirm no consumers were missed (grep is empty for `PAYWALL_ENV`, `paywall_env`, `paywallEnvironment`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)