### PR TITLE
ci: register shorebird-patch.yml on default branch

### DIFF
--- a/.github/workflows/shorebird-patch.yml
+++ b/.github/workflows/shorebird-patch.yml
@@ -1,0 +1,250 @@
+name: Shorebird Patch (OTA)
+
+# Ships a DART-ONLY over-the-air patch to an already-shipped release — no App
+# Store / Play review. Native code, plugin, MeditoWidgetExtension, permission, or
+# bundled-asset changes are NOT patchable (shorebird blocks on native/asset diffs
+# by default) — ship those via the "Build & Deploy" workflow instead.
+#
+# ALWAYS dispatch against the SAME ref (tag/commit) that was `shorebird release`d:
+#     gh workflow run shorebird-patch.yml --ref <release-tag> \
+#       -f platform=both -f track=staging
+# With release_version=latest (default) each job derives the exact release version
+# from the CHECKED-OUT pubspec.yaml, so the patch targets the release that matches
+# this ref (not whatever "latest" happens to be on the backend). Pass an explicit
+# "<name>+<build>" only to override.
+#
+# Patches default to the "staging" track — validate with `shorebird preview
+# --track staging`, then promote to "stable" (Shorebird console, or
+# `shorebird patches set-track ... --track stable`).
+
+on:
+  workflow_dispatch:
+    inputs:
+      platform:
+        description: 'Platform(s) to patch'
+        type: choice
+        options: [android, ios, both]
+        default: both
+      release_version:
+        description: 'Release to patch, e.g. 2606.30.0+302422 ("latest" = derive from this ref''s pubspec)'
+        type: string
+        default: latest
+      track:
+        description: 'Track to publish the patch to'
+        type: choice
+        options: [staging, stable]
+        default: staging
+
+jobs:
+  patch-android:
+    name: Android – Patch
+    if: inputs.platform == 'android' || inputs.platform == 'both'
+    runs-on: ubuntu-latest
+    environment: prod
+
+    steps:
+      - uses: actions/checkout@v4
+
+      # Resolve the release to patch. Default "latest" is derived from the
+      # checked-out pubspec.yaml so the patch targets the release matching THIS
+      # ref, not whatever was most recently updated on the Shorebird backend.
+      - name: Resolve release version
+        id: relver
+        run: |
+          if [ "${{ inputs.release_version }}" = "latest" ] || [ -z "${{ inputs.release_version }}" ]; then
+            V=$(grep '^version:' pubspec.yaml | sed 's/version: *//' | tr -d '[:space:]')
+            echo "Derived release version from checked-out pubspec.yaml: $V"
+          else
+            V="${{ inputs.release_version }}"
+          fi
+          echo "value=$V" >> "$GITHUB_OUTPUT"
+
+      - uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '17'
+
+      - uses: subosito/flutter-action@v2.12.0
+        with:
+          flutter-version: '3.44.1'
+          channel: stable
+          cache: true
+
+      - name: Flutter pub get
+        run: flutter pub get
+
+      # build_runner + pigeon outputs must exist before Shorebird rebuilds the app
+      # to compute the patch diff.
+      - name: Run build_runner
+        run: flutter packages pub run build_runner build --delete-conflicting-outputs
+
+      - name: Run pigeon
+        run: flutter pub run pigeon --input pigeon_conf.dart --package_name=medito
+
+      - name: Write .prod.json
+        env:
+          PROD_ENV: ${{ secrets.PROD_ENV }}
+        run: |
+          python3 - <<'PY'
+          import json, os, sys
+          raw = os.environ["PROD_ENV"]
+          try:
+            data = json.loads(raw)
+          except json.JSONDecodeError:
+            data = {}
+            for line in raw.strip().strip("{}").splitlines():
+              line = line.strip().rstrip(",")
+              if ":" in line:
+                key, _, value = line.partition(":")
+                data[key.strip()] = value.strip()
+          if not data:
+            sys.exit("Failed to parse PROD_ENV secret")
+          with open(".prod.json", "w") as f:
+            json.dump(data, f, indent=2)
+          PY
+
+      - name: Write google-services.json
+        env:
+          GOOGLE_SERVICES_JSON: ${{ secrets.GOOGLE_SERVICES_JSON }}
+        run: printf '%s' "$GOOGLE_SERVICES_JSON" > android/app/google-services.json
+
+      - name: Write firebase_options.dart
+        env:
+          FIREBASE_OPTIONS_DART: ${{ secrets.FIREBASE_OPTIONS_DART }}
+        run: printf '%s' "$FIREBASE_OPTIONS_DART" > lib/firebase_options.dart
+
+      - name: Write keystore.properties
+        env:
+          KEYSTORE_PROPERTIES: ${{ secrets.KEYSTORE_PROPERTIES }}
+        run: printf '%s' "$KEYSTORE_PROPERTIES" > android/keystore.properties
+
+      - name: Write keystore file
+        env:
+          KEYSTORE_FILE: ${{ secrets.KEYSTORE_FILE }}
+        run: printf '%s' "$KEYSTORE_FILE" | base64 -d > android/meditokey.jks
+
+      - name: Set up Shorebird
+        uses: shorebirdtech/setup-shorebird@v1
+
+      - name: Shorebird patch (Android)
+        env:
+          SHOREBIRD_TOKEN: ${{ secrets.SHOREBIRD_TOKEN }}
+        run: |
+          # Flavor + dart-defines MUST match the release build
+          # (release.yml → "Shorebird release (Android)") or the diff drifts.
+          # Do NOT pass --obfuscate/--split-debug-info here: Shorebird auto-matches
+          # the release's obfuscation on patch; re-passing perturbs the diff.
+          shorebird patch android \
+            --flutter-version=3.44.1 \
+            --flavor prod \
+            --release-version="${{ steps.relver.outputs.value }}" \
+            --track="${{ inputs.track }}" \
+            -- \
+            --dart-define-from-file=.prod.json \
+            --dart-define=MOCK_MODE=false
+
+  patch-ios:
+    name: iOS – Patch
+    if: inputs.platform == 'ios' || inputs.platform == 'both'
+    runs-on: macos-latest
+    environment: prod
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Resolve release version
+        id: relver
+        run: |
+          if [ "${{ inputs.release_version }}" = "latest" ] || [ -z "${{ inputs.release_version }}" ]; then
+            V=$(grep '^version:' pubspec.yaml | sed 's/version: *//' | tr -d '[:space:]')
+            echo "Derived release version from checked-out pubspec.yaml: $V"
+          else
+            V="${{ inputs.release_version }}"
+          fi
+          echo "value=$V" >> "$GITHUB_OUTPUT"
+
+      - name: Select Xcode (Icon Composer requires 26+)
+        uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: 'latest-stable'
+
+      - uses: subosito/flutter-action@v2.12.0
+        with:
+          flutter-version: '3.44.1'
+          channel: stable
+          cache: true
+
+      - name: Flutter pub get
+        run: flutter pub get
+
+      - name: Flutter precache iOS
+        run: flutter precache --ios
+
+      - name: Run build_runner
+        run: flutter packages pub run build_runner build --delete-conflicting-outputs
+
+      - name: Run pigeon
+        run: flutter pub run pigeon --input pigeon_conf.dart --package_name=medito
+
+      - name: Write .prod.json
+        env:
+          PROD_ENV: ${{ secrets.PROD_ENV }}
+        run: |
+          python3 - <<'PY'
+          import json, os, sys
+          raw = os.environ["PROD_ENV"]
+          try:
+            data = json.loads(raw)
+          except json.JSONDecodeError:
+            data = {}
+            for line in raw.strip().strip("{}").splitlines():
+              line = line.strip().rstrip(",")
+              if ":" in line:
+                key, _, value = line.partition(":")
+                data[key.strip()] = value.strip()
+          if not data:
+            sys.exit("Failed to parse PROD_ENV secret")
+          with open(".prod.json", "w") as f:
+            json.dump(data, f, indent=2)
+          PY
+
+      - name: Write firebase_options.dart
+        env:
+          FIREBASE_OPTIONS_DART: ${{ secrets.FIREBASE_OPTIONS_DART }}
+        run: printf '%s' "$FIREBASE_OPTIONS_DART" > lib/firebase_options.dart
+
+      - name: Write GoogleService-Info.plist
+        env:
+          GOOGLE_SERVICE_INFO_PLIST: ${{ secrets.GOOGLE_SERVICE_INFO_PLIST }}
+        run: printf '%s' "$GOOGLE_SERVICE_INFO_PLIST" | base64 -d > ios/Runner/GoogleService-Info.plist
+
+      # Bundler-managed fastlane so fastlane-plugin-shorebird loads. Prereq:
+      # `cd ios && fastlane add_plugin shorebird` committed (Gemfile/Gemfile.lock/Pluginfile).
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.2'
+          bundler-cache: true
+          working-directory: ios
+
+      - name: Set up Shorebird
+        uses: shorebirdtech/setup-shorebird@v1
+
+      - name: Shorebird patch (iOS)
+        working-directory: ios
+        env:
+          MATCH_READONLY: 'true'
+          FASTLANE_XCODEBUILD_SETTINGS_TIMEOUT: '120'
+          FASTLANE_XCODEBUILD_SETTINGS_RETRIES: '8'
+          MATCH_GIT_TOKEN: ${{ secrets.MATCH_GIT_TOKEN }}
+          MATCH_PASSWORD: ${{ secrets.MATCH_PASSWORD }}
+          DEVELOPER_APP_IDENTIFIER: ${{ secrets.DEVELOPER_APP_IDENTIFIER }}
+          DEVELOPER_PORTAL_TEAM_ID: ${{ secrets.DEVELOPER_PORTAL_TEAM_ID }}
+          APP_STORE_CONNECT_TEAM_ID: ${{ secrets.APP_STORE_CONNECT_TEAM_ID }}
+          TEMP_KEYCHAIN_USER: ${{ secrets.TEMP_KEYCHAIN_USER }}
+          TEMP_KEYCHAIN_PASSWORD: ${{ secrets.TEMP_KEYCHAIN_PASSWORD }}
+          PROVISIONING_PROFILE_SPECIFIER: ${{ secrets.PROVISIONING_PROFILE_SPECIFIER }}
+          ASC_KEY_ID: ${{ secrets.ASC_KEY_ID }}
+          ASC_ISSUER_ID: ${{ secrets.ASC_ISSUER_ID }}
+          ASC_KEY_CONTENT: ${{ secrets.ASC_KEY_CONTENT }}
+          SHOREBIRD_TOKEN: ${{ secrets.SHOREBIRD_TOKEN }}
+        run: bundle exec fastlane patch release_version:"${{ steps.relver.outputs.value }}" track:"${{ inputs.track }}"


### PR DESCRIPTION
GitHub only registers `workflow_dispatch` workflows that exist on the default branch — dispatching `shorebird-patch.yml` currently 404s because the file only lives on `shorebird-code-push`. This adds the identical file to `develop` so it can be dispatched. The `--ref` passed at dispatch time still controls which branch's copy runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)