### PR TITLE
fix(android): end screen not showing after session completes

### DIFF
--- a/.github/workflows/ci-develop.yml
+++ b/.github/workflows/ci-develop.yml
@@ -10,10 +10,15 @@ on:
     tags-ignore:
       - '*'
   pull_request:
+    # 'labeled' lets adding the auto-ready label kick off the checks + auto
+    # ready-for-review flow on a PR whose CI already ran.
+    types: [opened, synchronize, reopened, labeled]
   workflow_dispatch:
 
 jobs:
   checks:
+    # Don't re-run the full CI when unrelated labels are added.
+    if: github.event.action != 'labeled' || github.event.label.name == 'auto-ready'
     runs-on: ubuntu-latest
     timeout-minutes: 15
 
@@ -119,3 +124,24 @@ jobs:
         with:
           name: flutter-artifacts
           path: build/
+
+  # Opt-in: open the PR as a draft and add the 'auto-ready' label, and it is
+  # marked ready for review automatically once the checks job passes. Same-repo
+  # PRs only — on fork PRs the workflow token is read-only.
+  ready-for-review:
+    name: Mark ready for review
+    runs-on: ubuntu-latest
+    needs: checks
+    if: >-
+      github.event_name == 'pull_request' &&
+      github.event.pull_request.draft &&
+      contains(github.event.pull_request.labels.*.name, 'auto-ready')
+    permissions:
+      pull-requests: write
+    steps:
+      - name: Mark PR ready for review
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          GH_REPO: ${{ github.repository }}
+        run: gh pr ready "$PR_NUMBER" --repo "$GH_REPO"

--- a/.github/workflows/ci-develop.yml
+++ b/.github/workflows/ci-develop.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Flutter version
         uses: subosito/flutter-action@v2.12.0
         with:
-          flutter-version: '3.41.4'
+          flutter-version: '3.44.4'
 
       - name: Flutter Pub Get
         uses: nick-invision/retry@v2
@@ -134,6 +134,7 @@ jobs:
     needs: checks
     if: >-
       github.event_name == 'pull_request' &&
+      github.event.pull_request.head.repo.full_name == github.repository &&
       github.event.pull_request.draft &&
       contains(github.event.pull_request.labels.*.name, 'auto-ready')
     permissions:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,7 +46,7 @@ jobs:
 
       - uses: subosito/flutter-action@v2.12.0
         with:
-          flutter-version: '3.41.6'
+          flutter-version: '3.44.4'
           channel: stable
           cache: true
 
@@ -424,7 +424,7 @@ jobs:
 
       - uses: subosito/flutter-action@v2.12.0
         with:
-          flutter-version: '3.41.6'
+          flutter-version: '3.44.4'
           channel: stable
           cache: true
 
@@ -782,7 +782,7 @@ jobs:
 
       - uses: subosito/flutter-action@v2.12.0
         with:
-          flutter-version: '3.41.6'
+          flutter-version: '3.44.4'
           channel: stable
           cache: true
 

--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -30,7 +30,7 @@ jobs:
 
       - uses: subosito/flutter-action@v2.12.0
         with:
-          flutter-version: '3.41.4'
+          flutter-version: '3.44.4'
           cache: true
 
       - name: Cache pub packages
@@ -207,7 +207,7 @@ jobs:
 
       - uses: subosito/flutter-action@v2.12.0
         with:
-          flutter-version: '3.41.4'
+          flutter-version: '3.44.4'
           cache: true
 
       - name: Cache pub packages

--- a/android/app/src/main/kotlin/meditofoundation/medito/AudioPlayerService.kt
+++ b/android/app/src/main/kotlin/meditofoundation/medito/AudioPlayerService.kt
@@ -173,7 +173,10 @@ class AudioPlayerService : MediaSessionService(), Player.Listener, MeditoAudioSe
         if (!::primaryPlayer.isInitialized) return
         val api = meditoAudioApi ?: return
 
-        val duration = primaryPlayer.duration.takeIf { it != C.TIME_UNSET } ?: 0L
+        // Fall back to the playhead if ExoPlayer never resolved a duration —
+        // position must stay > 5s or PlayerView's end-screen guard rejects it.
+        val duration = primaryPlayer.duration.takeIf { it != C.TIME_UNSET }
+            ?: primaryPlayer.currentPosition
         val state = PlaybackState(
             isPlaying = false,
             position = duration,

--- a/android/app/src/main/kotlin/meditofoundation/medito/AudioPlayerService.kt
+++ b/android/app/src/main/kotlin/meditofoundation/medito/AudioPlayerService.kt
@@ -122,18 +122,7 @@ class AudioPlayerService : MediaSessionService(), Player.Listener, MeditoAudioSe
                     duration = primaryPlayer.duration,
                     isSeeking = primaryPlayer.playbackState == Player.STATE_BUFFERING,
                     isCompleted = primaryPlayer.playbackState == Player.STATE_ENDED,
-                    track = primaryPlayer.currentMediaItem?.let { mediaItem ->
-                        Track(
-                            id = mediaItem.mediaId,
-                            title = mediaItem.mediaMetadata.title?.toString() ?: "",
-                            fileId = mediaItem.mediaMetadata.extras?.getString(KEY_FILE_ID) ?: "",
-                            description = mediaItem.mediaMetadata.description?.toString()
-                                ?: "",
-                            imageUrl = mediaItem.mediaMetadata.artworkUri?.toString() ?: "",
-                            artist = mediaItem.mediaMetadata.artist?.toString() ?: "",
-                            artistUrl = mediaItem.mediaMetadata.extras?.getString(KEY_ARTIST_URL),
-                        )
-                    } ?: Track(id = "", title = "", fileId = "", description = "", imageUrl = "", artist = null, artistUrl = null)
+                    track = trackFromCurrentMediaItem()
                 )
             } ?: return
 
@@ -160,6 +149,44 @@ class AudioPlayerService : MediaSessionService(), Player.Listener, MeditoAudioSe
         } finally {
             isUpdatingPlaybackState = false
         }
+    }
+
+    private fun trackFromCurrentMediaItem(): Track {
+        return primaryPlayer.currentMediaItem?.let { mediaItem ->
+            Track(
+                id = mediaItem.mediaId,
+                title = mediaItem.mediaMetadata.title?.toString() ?: "",
+                fileId = mediaItem.mediaMetadata.extras?.getString(KEY_FILE_ID) ?: "",
+                description = mediaItem.mediaMetadata.description?.toString() ?: "",
+                imageUrl = mediaItem.mediaMetadata.artworkUri?.toString() ?: "",
+                artist = mediaItem.mediaMetadata.artist?.toString() ?: "",
+                artistUrl = mediaItem.mediaMetadata.extras?.getString(KEY_ARTIST_URL),
+            )
+        } ?: Track(id = "", title = "", fileId = "", description = "", imageUrl = "", artist = null, artistUrl = null)
+    }
+
+    // Sends the terminal isCompleted=true PlaybackState to Dart. Called from the
+    // native STATE_ENDED handler on the main thread, before finishPlayback()
+    // cancels the position poll — the poll would otherwise be the only sender of
+    // isCompleted and it never gets to run once the track ends.
+    private fun pushCompletedStateToDart() {
+        if (!::primaryPlayer.isInitialized) return
+        val api = meditoAudioApi ?: return
+
+        val duration = primaryPlayer.duration.takeIf { it != C.TIME_UNSET } ?: 0L
+        val state = PlaybackState(
+            isPlaying = false,
+            position = duration,
+            volume = primaryPlayer.volume.toLong(),
+            speed = Speed(primaryPlayer.playbackParameters.speed.toDouble()),
+            isBuffering = false,
+            duration = duration,
+            isSeeking = false,
+            isCompleted = true,
+            track = trackFromCurrentMediaItem()
+        )
+
+        api.updatePlaybackState(state) { /* fire-and-forget */ }
     }
 
     private fun handleTrackCompletion(state: PlaybackState) {
@@ -481,6 +508,10 @@ class AudioPlayerService : MediaSessionService(), Player.Listener, MeditoAudioSe
             // updateNotification() below avoids re-posting the stuck "ended" card.
             if (!isCompletionHandled) {
                 isCompletionHandled = true
+                // Push a final isCompleted=true state to Dart before teardown:
+                // finishPlayback() cancels the position poll before it can observe
+                // STATE_ENDED, and PlayerView opens the end screen off that flag.
+                pushCompletedStateToDart()
                 handleTrackCompletionFromPlayer()
             }
             return

--- a/release_notes.txt
+++ b/release_notes.txt
@@ -1,5 +1,6 @@
 Unreleased
 - Removed the unnecessary notification prompt from the player screen
+- Fixed the end-of-session screen not appearing on Android when a meditation finishes
 
 2606.26.0
 - Fixed reminders not showing for some users


### PR DESCRIPTION
Since 84c4021, STATE_ENDED is handled natively and finishPlayback()
cancels the ~1/s position poll immediately — before the poll can push a
PlaybackState with isCompleted=true to Dart. PlayerView opens
EndScreenView off that flag, so the end screen never appeared on
Android (stats still updated via the separate handleCompletedTrack
callback).

Push one final isCompleted=true state to Dart from the STATE_ENDED
handler before teardown, mirroring how onTaskRemoved pushes a last
snapshot. Position is set to the track duration so PlayerView's
position > 5s guard passes. The track mapping is extracted from
updatePlaybackState() and shared.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_014y6ZU7V45pnpxEGA94dpEU