### PR TITLE
ci: tag the release automatically after a successful deploy

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -959,3 +959,35 @@ jobs:
               fastlane release submit_for_review:"${{ inputs.submit_for_review }}"
             fi
           fi
+
+  # After a successful deploy, tag the built commit with the pubspec version
+  # (bare semver, no v prefix — matches existing tags). Runs only when at
+  # least one deploy job actually deployed, and is a no-op if the tag already
+  # exists, so re-runs and manual tags don't conflict.
+  tag-release:
+    name: Tag release
+    runs-on: ubuntu-latest
+    needs: [android-deploy, ios-deploy]
+    if: >-
+      !failure() && !cancelled() &&
+      contains(needs.*.result, 'success')
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+      - name: Tag commit with pubspec version
+        run: |
+          VERSION=$(grep '^version:' pubspec.yaml | sed 's/version: *//' | cut -d'+' -f1)
+          if [ -z "$VERSION" ]; then
+            echo "::error::Could not read version from pubspec.yaml"
+            exit 1
+          fi
+          if git ls-remote --tags origin "refs/tags/$VERSION" | grep -q .; then
+            echo "Tag $VERSION already exists — nothing to do."
+            exit 0
+          fi
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git tag "$VERSION"
+          git push origin "$VERSION"
+          echo "Created tag $VERSION at $GITHUB_SHA"


### PR DESCRIPTION
## Why

Releases cut from Claude Code cloud sessions can push commits but not tags (tag creation is denied for that credential), so the `2607.5.0` release commit is on `develop` with no tag. Tags matter here: `prepare_release.sh` derives the next version from them, the Android upgrade test resolves its baseline from the previous release tag, and shorebird patches are dispatched against release tags.

## What

Adds a `tag-release` job to Build & Deploy: after `android-deploy` / `ios-deploy` finish without failure — and at least one of them actually deployed — it tags the built commit with the version name from `pubspec.yaml` (bare semver, no `v` prefix, matching existing tags) using the Actions token (`contents: write`).

- No-op if the tag already exists, so re-runs and manually pushed tags don't conflict.
- Skipped entirely when both platform chains were toggled off or anything failed.

## Notes

- The next dispatched run of Build & Deploy on `develop` will create the missing `2607.5.0` tag automatically (the built commit carries that pubspec version).
- If a tag ruleset also denies `github-actions[bot]`, this job will fail visibly rather than silently — in that case the ruleset needs a bypass entry for Actions, or tags stay manual.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014y6ZU7V45pnpxEGA94dpEU

---
_Generated by [Claude Code](https://claude.ai/code/session_014y6ZU7V45pnpxEGA94dpEU)_