### PR TITLE
fix(release): build iOS once when TestFlight + App Store are both dispatched

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1006,7 +1006,20 @@ jobs:
               bundle exec fastlane beta
             fi
             if [ "${{ inputs.ios_appstore }}" = "true" ]; then
-              bundle exec fastlane release submit_for_review:"${{ inputs.submit_for_review }}"
+              if [ "${{ inputs.ios_testflight }}" = "true" ]; then
+                # The beta lane above already built this version and uploaded
+                # it to App Store Connect. Building again is guaranteed to fail
+                # (`shorebird release ios` exits 70 on an existing release), so
+                # point the release lane at the build beta just uploaded and
+                # let deliver attach it instead of rebuilding.
+                version=$(grep '^version:' ../pubspec.yaml | sed 's/version: *//')
+                bundle exec fastlane release \
+                  submit_for_review:"${{ inputs.submit_for_review }}" \
+                  app_version:"${version%+*}" \
+                  build_number:"${version#*+}"
+              else
+                bundle exec fastlane release submit_for_review:"${{ inputs.submit_for_review }}"
+              fi
             fi
           fi
 

--- a/ios/fastlane/Fastfile
+++ b/ios/fastlane/Fastfile
@@ -78,8 +78,17 @@ platform :ios do
   end
 
   # App Store release (draft; not auto-submitted for review).
+  #
+  # Pass app_version + build_number to attach a build that is ALREADY on App
+  # Store Connect (e.g. the one the beta lane just uploaded in the same
+  # workflow run) instead of building again. `shorebird release ios` hard-fails
+  # (exit 70, "existing ios release") when a release for the version already
+  # exists, so rebuilding after a beta run of the same version can never work.
+  # With no build_number the lane builds & uploads exactly as before.
   lane :release do |options|
-    setup_keychain()
+    use_existing_build = options[:build_number].to_s != ''
+
+    setup_keychain() unless use_existing_build
 
     app_store_connect_api_key(
       key_id: ENV["ASC_KEY_ID"],
@@ -89,7 +98,7 @@ platform :ios do
       in_house: false
     )
 
-    build_shorebird_release
+    build_shorebird_release unless use_existing_build
 
     # submit_for_review:true sends the uploaded version straight to App Store
     # review; the default keeps today's behaviour (draft version, submitted by
@@ -100,7 +109,7 @@ platform :ios do
     submit = options[:submit_for_review].to_s == 'true'
 
     notes = ENV["RELEASE_NOTES"] || ""
-    upload_to_app_store(
+    upload_options = {
       submit_for_review: submit,
       automatic_release: false,
       force: true,
@@ -116,8 +125,23 @@ platform :ios do
         "fr-FR" => notes,
         "de-DE" => notes
       }
-    )
-    cleanup_keychain()
+    }
+
+    if use_existing_build
+      # No ipa to read the version from, so deliver needs both explicitly.
+      # Build selection happens at submission time: with submit_for_review:true
+      # deliver picks the build with this build_number (the beta lane's
+      # upload_to_testflight has already waited for it to finish processing);
+      # with submit_for_review:false the version stays a draft and the build is
+      # attached by hand in ASC — same as the build-and-upload path, where
+      # uploading the binary doesn't attach it to the version either.
+      upload_options[:skip_binary_upload] = true
+      upload_options[:app_version] = options[:app_version]
+      upload_options[:build_number] = options[:build_number]
+    end
+
+    upload_to_app_store(**upload_options)
+    cleanup_keychain() unless use_existing_build
   end
 
   # Dart-only over-the-air patch against an already-shipped release. Does NOT


### PR DESCRIPTION
## Problem

Dispatching `release.yml` with **ios_testflight=true AND ios_appstore=true** runs `fastlane beta` then `fastlane release`, and both lanes call `build_shorebird_release`. `shorebird release ios` hard-fails with exit 70 ("existing ios release for version X") when the release already exists — so the App Store lane **always** failed right after a successful TestFlight lane in the same run. Observed in run [30109853985](https://github.com/meditohq/medito-app/actions/runs/30109853985): beta uploaded 2607.24.0+302438 to TestFlight, then the release lane rebuilt and died on the Shorebird collision.

## Fix

Build once, attach the same build to the App Store version:

- **`ios/fastlane/Fastfile`** — the `release` lane now accepts optional `app_version` + `build_number`. When given, it skips the keychain setup and `build_shorebird_release` entirely and runs `upload_to_app_store` with `skip_binary_upload: true` plus those two params, so deliver attaches the already-uploaded build (build selection happens at submission; the beta lane's `upload_to_testflight` has already waited for processing). With no `build_number` the lane builds & uploads exactly as before.
- **`.github/workflows/release.yml`** — when both toggles are set, the App Store step reads `version`/`build` from `pubspec.yaml` and passes them to the release lane instead of rebuilding.

## Preserved behaviour

- `ios_appstore` alone still builds (unchanged single-toggle path).
- `ios_testflight` alone unchanged.
- Non-dispatch trigger (`fastlane release` with no args) unchanged.
- `automatic_release: false` and the `submit_for_review` semantics (draft by default, manual release after approval) untouched.
- With `submit_for_review:false` the version stays a draft and the build is attached by hand in ASC — same as the build-and-upload path today, where uploading the binary doesn't attach it to the version either.

## Verification

- `ruby -c` on the Fastfile and YAML parse of the workflow both pass.
- Shell expansion checked against current pubspec (`2607.24.0+302439` → `app_version:2607.24.0 build_number:302439`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)