### PR TITLE
fix: correct 'unkown' to 'unknown' typo in user-facing error messages

### DIFF
--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -61,7 +61,7 @@
   "unauthorizedRequest": "Session expired - please sign in again",
   "accessForbidden": "Access forbidden",
   "apiNotFound": "Api not found",
-  "anErrorOccurred": "An unkown error occurred. Either we're having issues or you're offline.",
+  "anErrorOccurred": "An unknown error occurred. Either we're having issues or you're offline.",
   "unableToLoadAudio": "Unable to load audio. Please go back and try again",
   "loadingError": "It looks like you're offline or there was little hiccup from our end",
   "timeout": "Oops! It seems like there was an error. If the problem persists, Close the app and try again.",
@@ -630,7 +630,7 @@
   "@timeoutErrorMessage": {
     "description": "Error message for timeout errors"
   },
-  "anErrorOccurredMessage": "An unkown error occurred. Either we're having issues or you're offline.",
+  "anErrorOccurredMessage": "An unknown error occurred. Either we're having issues or you're offline.",
   "@anErrorOccurredMessage": {
     "description": "Generic error message for unknown errors"
   },

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -467,7 +467,7 @@ abstract class AppLocalizations {
   /// No description provided for @anErrorOccurred.
   ///
   /// In en, this message translates to:
-  /// **'An unkown error occurred. Either we\'re having issues or you\'re offline.'**
+  /// **'An unknown error occurred. Either we\'re having issues or you\'re offline.'**
   String get anErrorOccurred;
 
   /// No description provided for @unableToLoadAudio.
@@ -2891,7 +2891,7 @@ abstract class AppLocalizations {
   /// Generic error message for unknown errors
   ///
   /// In en, this message translates to:
-  /// **'An unkown error occurred. Either we\'re having issues or you\'re offline.'**
+  /// **'An unknown error occurred. Either we\'re having issues or you\'re offline.'**
   String get anErrorOccurredMessage;
 
   /// Section title for help settings

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -197,7 +197,7 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get anErrorOccurred =>
-      'An unkown error occurred. Either we\'re having issues or you\'re offline.';
+      'An unknown error occurred. Either we\'re having issues or you\'re offline.';
 
   @override
   String get unableToLoadAudio =>
@@ -1554,7 +1554,7 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get anErrorOccurredMessage =>
-      'An unkown error occurred. Either we\'re having issues or you\'re offline.';
+      'An unknown error occurred. Either we\'re having issues or you\'re offline.';
 
   @override
   String get helpLegalSection => 'Help';

--- a/lib/providers/error_widget/medito_error_widget_provider.dart
+++ b/lib/providers/error_widget/medito_error_widget_provider.dart
@@ -18,7 +18,7 @@ final meditoErrorWidgetProvider =
       } catch (e) {
         return MeditoErrorWidgetUIState(
           false,
-          "An unknown error occurred. Either we're having issues or you're offline.",
+'An unknown error occurred. Either we\'re having issues or you\'re offline.'
         );
       }
     });

--- a/lib/providers/error_widget/medito_error_widget_provider.dart
+++ b/lib/providers/error_widget/medito_error_widget_provider.dart
@@ -18,7 +18,7 @@ final meditoErrorWidgetProvider =
       } catch (e) {
         return MeditoErrorWidgetUIState(
           false,
-          "An unkown error occurred. Either we're having issues or you're offline.",
+          "An unknown error occurred. Either we're having issues or you're offline.",
         );
       }
     });


### PR DESCRIPTION
## Summary
Fix 3 instances of `unkown` → `unknown` typo in user-facing error text shown to app users.

## Files Changed
- `lib/providers/error_widget/medito_error_widget_provider.dart` — main error UI message (line 21)
- `lib/l10n/app_en.arb` — English localization source (lines 64, 633)
- `lib/l10n/app_localizations.dart` & `lib/l10n/app_localizations_en.dart` — generated localization files

## User-Facing Impact
The error message `An unkown error occurred. Either we're having issues or you're offline.` is displayed in the app's error widget when something goes wrong. This typo appears in the UI shown to end users.

## Testing
The fix is a simple string replacement with no behavioral change. The Flutter localization system will pick up the corrected strings on next `gen-l10n` run.

---
fix typo in Dart/Flutter app (1283★, 0 open PRs)