### PR TITLE
chore(onboarding): remove leftover internal-testing flags

### DIFF
--- a/lib/views/onboarding/onboarding_donation_screen.dart
+++ b/lib/views/onboarding/onboarding_donation_screen.dart
@@ -25,11 +25,6 @@ class OnboardingDonationScreen extends ConsumerStatefulWidget {
 }
 
 class _DonationScreenState extends ConsumerState<OnboardingDonationScreen> {
-  // TODO(temp): remove before activating the real native-vs-webview
-  // experiment. Forces the native page on the internal-testing release so it
-  // can be validated on-device before any server config carries the flag.
-  static const _forceNativeForInternalTesting = false;
-
   static const _paywallConfigTimeout = Duration(seconds: 3);
 
   bool _hasAttemptedDonation = isSmokeTestMode;
@@ -135,8 +130,7 @@ class _DonationScreenState extends ConsumerState<OnboardingDonationScreen> {
 
     if (_useNativePaywall == null) {
       if (config != null) {
-        _useNativePaywall =
-            _forceNativeForInternalTesting || config.nativePaywallEnabled;
+        _useNativePaywall = config.nativePaywallEnabled;
       } else if (paywallAsync.hasError || _configTimedOut) {
         _useNativePaywall = false;
       }

--- a/lib/views/settings/widgets/expandable_section_widget.dart
+++ b/lib/views/settings/widgets/expandable_section_widget.dart
@@ -17,10 +17,6 @@ import 'package:medito/views/settings/widgets/day_boundary_offset_dialog.dart';
 import 'package:medito/widgets/medito_icon.dart';
 // removed unused snackbar import
 
-// TODO(temp): remove with the force-native flag in
-// onboarding_donation_screen.dart.
-const _showOnboardingEntryForInternalTesting = true;
-
 class ExpandableSectionWidget extends ConsumerStatefulWidget {
   const ExpandableSectionWidget({super.key});
 
@@ -277,11 +273,10 @@ class _ExpandableSectionWidgetState
                       ),
                     ),
                   ),
-                  // Onboarding Item (only in debug mode)
-                  // TODO(temp): temporarily also shown on the internal-testing
-                  // release to reach the native donation page; restore to
-                  // kDebugMode with the force-native flag removal.
-                  if (kDebugMode || _showOnboardingEntryForInternalTesting)
+                  // Onboarding Item (only in debug mode). Replaying onboarding
+                  // re-fires experiment exposure and paywall events and resets
+                  // persisted onboarding state, so it must never ship enabled.
+                  if (kDebugMode)
                     InkWell(
                       onTap: () => _showOnboardingScreen(context),
                       child: Padding(


### PR DESCRIPTION
## Problem

`_showOnboardingEntryForInternalTesting` was left at `true` when its twin force-native flag was reverted in `dc3c956a`. The gate in `expandable_section_widget.dart` read:

```dart
if (kDebugMode || _showOnboardingEntryForInternalTesting)
```

`ExpandableSectionWidget` is mounted unguarded from `settings_screen.dart:489`, so **production** users could open Settings → Advanced and tap "Onboarding", pushing a full `OnboardingPagerScreen`.

This shipped in **2607.20.0, .1, .2, .3, 2607.21.0 and 2607.24.0**.

Replaying onboarding from there:

- re-fires `onboarding_experiment_exposure`, contaminating the live `onboarding_reminder_time_chips` experiment
- re-fires `paywall_presented` (`native_paywall` experiment)
- re-fires `onboarding_completed`
- overwrites persisted `onboardingExperienceLevel`, `upNextPackId` and `firstActionAfterOnboardingPending`

## Changes

1. **`expandable_section_widget.dart`** — delete the const, restore the bare `if (kDebugMode)`, and drop both `TODO(temp)` blocks. The replacement comment records *why* this must never ship enabled.

2. **`onboarding_donation_screen.dart`** — delete `_forceNativeForInternalTesting` entirely. Its value was already `false`, but it remained OR'd into live `native_paywall` arm selection, so a one-character edit would re-ship the 2607.20.0–.2 incident where every user was forced onto the native page. Line 139 now reads `config.nativePaywallEnabled` alone.

No other behaviour changed.

## Verification

Ran locally, mirroring `ci-develop.yml` (`build_runner` → `pigeon` → analyze → test):

- `flutter analyze --no-fatal-infos` → **No issues found**
- `flutter test --dart-define-from-file=.prod.json` → **363/363 passed**

Note for reviewers: a fresh worktree reports ~899 analyze errors *before* codegen — that is entirely missing generated code, not this change. `build_runner` + `pigeon` clears all of them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
